### PR TITLE
Make DB set rolledback to the function return

### DIFF
--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RestoreCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RestoreCommand.kt
@@ -53,10 +53,8 @@ object RestoreCommand : BuildableCommand {
                 val fails = HashMap<String, Int>()
 
                 for (action in actions) {
-                    if (!action.restore(context.source.server)) {
-                        fails[action.identifier] = fails.getOrPut(action.identifier) { 0 } + 1
-                    }
-                    action.rolledBack = true
+                    action.rolledBack = action.rollback(context.source.server)
+                    if (!action.rolledBack) {fails[action.identifier] = fails.getOrPut(action.identifier) { 0 } + 1}
                 }
 
                 for (entry in fails.entries) {
@@ -76,6 +74,7 @@ object RestoreCommand : BuildableCommand {
                     true
                 )
             }
+            DatabaseManager.updateRollbackState(params,actions)
         }
         return 1
     }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RollbackCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RollbackCommand.kt
@@ -55,10 +55,8 @@ object RollbackCommand : BuildableCommand {
                 val fails = HashMap<String, Int>()
 
                 for (action in actions) {
-                    if (!action.rollback(context.source.server)) {
-                        fails[action.identifier] = fails.getOrPut(action.identifier) { 0 } + 1
-                    }
-                    action.rolledBack = true
+                    action.rolledBack = action.rollback(context.source.server)
+                    if (!action.rolledBack) {fails[action.identifier] = fails.getOrPut(action.identifier) { 0 } + 1}
                 }
 
                 for (entry in fails.entries) {
@@ -78,6 +76,7 @@ object RollbackCommand : BuildableCommand {
                     true
                 )
             }
+            DatabaseManager.updateRollbackState(params,actions)
         }
         return 1
     }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
@@ -443,6 +443,8 @@ object DatabaseManager {
         updatedActions.zip(actionDB).forEach{ loopBoth ->
             loopBoth.component2().rolledBack = loopBoth.component1().rolledBack
         }
+
+        // i think theres a way to do this just by using the ID of each, could probs also only return in the list of rolledback to
     }
 
     private fun Transaction.selectRestoreActions(params: ActionSearchParams): MutableList<ActionType> {


### PR DESCRIPTION
companion to #111

currently it changes:

selectRollbackActions & selectRestoreActions now will not change this value

updateRollbackedActions instead is used, it takes the query & actionType list that was edited by the rollback/restore function.  