### PR TITLE
Update Modrinth Minotaur

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import com.modrinth.minotaur.TaskModrinthUpload
 
 plugins {
     kotlin("jvm") version "1.6.10"
-    id("fabric-loom") version "0.11.+"
+    id("fabric-loom") version "0.12.+"
     id("maven-publish")
     id("io.gitlab.arturbosch.detekt") version "1.19.0"
     id("com.github.jakemarsden.git-hooks") version "0.0.2"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,6 @@ import com.matthewprenger.cursegradle.CurseProject
 import com.matthewprenger.cursegradle.CurseRelation
 import com.matthewprenger.cursegradle.Options
 import com.modrinth.minotaur.TaskModrinthUpload
-import com.modrinth.minotaur.request.Dependency.DependencyType
-import com.modrinth.minotaur.request.VersionType
 
 plugins {
     kotlin("jvm") version "1.6.10"
@@ -12,7 +10,7 @@ plugins {
     id("io.gitlab.arturbosch.detekt") version "1.19.0"
     id("com.github.jakemarsden.git-hooks") version "0.0.2"
     id("com.github.johnrengelman.shadow") version "7.1.0"
-    id("com.modrinth.minotaur") version "1.2.1"
+    id("com.modrinth.minotaur") version "2.+"
     id("com.matthewprenger.cursegradle") version "1.4.0"
 }
 
@@ -184,6 +182,10 @@ tasks {
             jvmTarget = javaVersion.toString()
         }
     }
+
+    withType<TaskModrinthUpload> {
+        onlyIf { System.getenv().contains("MODRINTH_TOKEN") }
+    }
 }
 
 // configure the maven publication
@@ -218,7 +220,7 @@ curseforge {
             mainArtifact(tasks["remapJar"])
 
             relations(closureOf<CurseRelation> {
-                props["cfReqDeps"].toString().split(",").forEach {
+                props["dependencies"].toString().split(",").forEach {
                     requiredDependency(it)
                 }
             })
@@ -230,34 +232,27 @@ curseforge {
     }
 }
 
-tasks {
-    register<TaskModrinthUpload>("publishModrinth") {
-        onlyIf { System.getenv().contains("MODRINTH_TOKEN") }
-        dependsOn("build")
+modrinth {
+    projectId.set("ledger")
+    versionType.set("release")
+    versionNumber.set(modVersion)
+    changelog.set(System.getenv("CHANGELOG"))
 
-        group = "upload"
+    gameVersions.add(libs.versions.minecraft.get())
+    loaders.set(listOf("fabric", "quilt"))
 
-        token = System.getenv("MODRINTH_TOKEN")
-
-        projectId = "LVN9ygNV"
-        versionType = VersionType.RELEASE
-        version = modVersion
-        changelog = System.getenv("CHANGELOG")
-
-        addGameVersion(libs.versions.minecraft.get())
-        addLoader("fabric")
-
-        props["mrReqDeps"].toString().split(",").forEach {
-            addDependency(it, DependencyType.REQUIRED)
+    dependencies {
+        props["dependencies"].toString().split(",").forEach {
+            required.project(it)
         }
-
-        uploadFile = remapJar.get().archiveFile.get()
     }
+
+    uploadFile.set(tasks.remapJar.get())
 }
 
 tasks.register("release") {
     release = true
-    dependsOn("curseforge", "publishModrinth")
+    dependsOn("curseforge", "modrinth")
 }
 
 detekt {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,4 @@ mavenGroup = com.github.quiltservertools
 modId = ledger
 modName = Ledger
 
-cfReqDeps = fabric-api,fabric-language-kotlin
-# FAPI, FLK
-mrReqDeps = c1p9mmFg,1qsZV7U7
+dependencies = fabric-api,fabric-language-kotlin


### PR DESCRIPTION
I know @PotatoPresident said he wanted to switch to mc-publish at one point or another, but the switch away from 1.x is a rather urgent one considering dependencies in 1.x are not and have never been supported. As it stands right now, your Minotaur configuration is resulting in dependencies being listed incorrectly. I've gone through and fixed the dependencies on the versions already on the site, but please do not make a new release without first merging this or switching to mc-publish.
