### PR TITLE
Allow usernames to be excluded from logging in the config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -49,7 +49,7 @@ blocks = ["minecraft:air", "minecraft:dirt"]
 
 `objectBlacklist` [Default: empty] controls which objects are logged. These can be item types, block types or entities
 
-`sourceBlacklist` [Default: empty] controls which sources are logged. Examples are `"lava"` and `"gravity"`
+`sourceBlacklist` [Default: empty] controls which sources are logged. Examples are `"lava"`, `"@playerName"` and `"gravity"`. Player names can be specified by prefixing them with `"@"`
 
 ## Default Config
 ```toml
@@ -87,7 +87,7 @@ typeBlacklist = []
 worldBlacklist = []
 # Blacklists objects (Items, Mobs, Blocks). Ex: "minecraft:cobblestone", "minecraft:blaze"
 objectBlacklist = []
-# Blacklists sources. Ex: "lava", "gravity", "fire", "fall"
+# Blacklists sources. Ex: "lava", "gravity", "fire", "fall", "@playerName"
 sourceBlacklist = []
 
 [networking]

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ActionType.kt
@@ -31,6 +31,7 @@ interface ActionType {
     fun previewRollback(player: ServerPlayerEntity)
     fun previewRestore(player: ServerPlayerEntity)
     fun getTranslationType(): String
+
     @ExperimentalTime
     fun getMessage(): Text
 
@@ -38,5 +39,6 @@ interface ActionType {
             config[ActionsSpec.objectBlacklist].contains(objectIdentifier) ||
             config[ActionsSpec.objectBlacklist].contains(oldObjectIdentifier) ||
             config[ActionsSpec.sourceBlacklist].contains(sourceName) ||
+            config[ActionsSpec.sourceBlacklist].contains("@${sourceProfile?.name}") ||
             config[ActionsSpec.worldBlacklist].contains(world)
 }


### PR DESCRIPTION
`sourceBlacklist` in the config can now include player names as sources in the format "@username":

```toml
sourceBlacklist = ["@potatoboy9999"]
```

Fixes #212 