### PR TITLE
Add parameter to filter searches by rollback status

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -4,7 +4,7 @@ Ledger supports numerous custom packets for interacting with supported client mo
 
 ## Versions
 
-The information on this page is applicable for Ledger Networking version 2, which is the version in Ledger versions `1.2.0` and later
+The information on this page is applicable for Ledger Networking versions 3, which is the version in Ledger versions `1.2.10` and later
 
 ## Packet Types
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -82,3 +82,12 @@ The `before` parameter selects all results before the point in time that was the
 An easy way to remember the difference between `before:1d` and `after:1d` is to think about it like this.
 If you go back in time 1 day, do you want everything that happened `before` then or `after` then.
 Usually you want `after`.
+
+### Rollback Status
+Key - `rolledBack:`  
+Value - `true` or `false`  
+Negative Allowed - `No`  
+Multiple Allowed - `No`  
+Example - `rolledBack:true`  
+
+This parameter allows you to filter by rollback state. If true, then it will only show results that have already been rolled back. If false, then it will only show results that have not been rolled back.

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionSearchParams.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionSearchParams.kt
@@ -9,16 +9,18 @@ data class ActionSearchParams(
     val bounds: BlockBox?,
     val before: Instant?,
     val after: Instant?,
+    val rolledBack: Boolean?,
     var actions: MutableSet<Negatable<String>>?,
     var objects: MutableSet<Negatable<Identifier>>?,
     var sourceNames: MutableSet<Negatable<String>>?,
     var sourcePlayerNames: MutableSet<Negatable<String>>?,
-    var worlds: MutableSet<Negatable<Identifier>>?,
+    var worlds: MutableSet<Negatable<Identifier>>?
 ) {
     private constructor(builder: Builder) : this(
         builder.bounds,
         builder.before,
         builder.after,
+        builder.rolledBack,
         builder.actions,
         builder.objects,
         builder.sourceNames,
@@ -26,7 +28,7 @@ data class ActionSearchParams(
         builder.worlds
     )
 
-    fun isEmpty() = listOf(bounds, before, after, actions, objects, sourceNames, sourcePlayerNames, worlds).all { it == null }
+    fun isEmpty() = listOf(bounds, before, after, actions, objects, sourceNames, sourcePlayerNames, worlds, rolledBack).all { it == null }
 
     companion object {
         inline fun build(block: Builder.() -> Unit) = Builder().apply(block).build()
@@ -36,6 +38,7 @@ data class ActionSearchParams(
         var bounds: BlockBox? = null
         var before: Instant? = null
         var after: Instant? = null
+        var rolledBack: Boolean? = null
         var actions: MutableSet<Negatable<String>>? = null
         var objects: MutableSet<Negatable<Identifier>>? = null
         var sourceNames: MutableSet<Negatable<String>>? = null

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
@@ -39,6 +39,7 @@ object SearchParamArgument {
         paramSuggesters["world"] = NegatableParameter(DimensionParameter())
         paramSuggesters["before"] = Parameter(TimeParameter())
         paramSuggesters["after"] = Parameter(TimeParameter())
+        paramSuggesters["rolledBack"] = Parameter(RollbackStatusParameter())
     }
 
     fun argument(name: String): RequiredArgumentBuilder<ServerCommandSource, String> {
@@ -160,6 +161,10 @@ object SearchParamArgument {
                 "after" -> {
                     val time = value as Instant
                     builder.after = time
+                }
+                "rolledBack" -> {
+                    val rolledBack = value as Boolean
+                    builder.rolledBack = rolledBack
                 }
             }
         }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
@@ -5,6 +5,7 @@ import com.github.quiltservertools.ledger.commands.parameters.ActionParameter
 import com.github.quiltservertools.ledger.commands.parameters.DimensionParameter
 import com.github.quiltservertools.ledger.commands.parameters.ObjectParameter
 import com.github.quiltservertools.ledger.commands.parameters.RangeParameter
+import com.github.quiltservertools.ledger.commands.parameters.RollbackStatusParameter
 import com.github.quiltservertools.ledger.commands.parameters.SimpleParameter
 import com.github.quiltservertools.ledger.commands.parameters.SourceParameter
 import com.github.quiltservertools.ledger.commands.parameters.TimeParameter

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/parameters/RollbackStatusParameter.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/parameters/RollbackStatusParameter.kt
@@ -10,10 +10,7 @@ import net.minecraft.server.command.ServerCommandSource
 import java.util.concurrent.CompletableFuture
 
 class RollbackStatusParameter : SimpleParameter<Boolean>() {
-    override fun parse(stringReader: StringReader): Boolean {
-        val res = BoolArgumentType.bool().parse(stringReader)
-        return res
-    }
+    override fun parse(stringReader: StringReader): Boolean = BoolArgumentType.bool().parse(stringReader)
 
     override fun getSuggestions(
         context: CommandContext<ServerCommandSource>?,

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/parameters/RollbackStatusParameter.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/parameters/RollbackStatusParameter.kt
@@ -1,0 +1,22 @@
+package com.github.quiltservertools.ledger.commands.parameters
+
+import com.mojang.brigadier.StringReader
+import com.mojang.brigadier.arguments.BoolArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.suggestion.Suggestions
+import com.mojang.brigadier.suggestion.SuggestionsBuilder
+import net.minecraft.command.CommandSource
+import net.minecraft.server.command.ServerCommandSource
+import java.util.concurrent.CompletableFuture
+
+class RollbackStatusParameter : SimpleParameter<Boolean>() {
+    override fun parse(stringReader: StringReader): Boolean {
+        val res = BoolArgumentType.bool().parse(stringReader)
+        return res
+    }
+
+    override fun getSuggestions(
+        context: CommandContext<ServerCommandSource>?,
+        builder: SuggestionsBuilder?
+    ): CompletableFuture<Suggestions> =CommandSource.suggestMatching(setOf("true", "false"), builder)
+}

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/parameters/RollbackStatusParameter.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/parameters/RollbackStatusParameter.kt
@@ -13,7 +13,7 @@ class RollbackStatusParameter : SimpleParameter<Boolean>() {
     override fun parse(stringReader: StringReader): Boolean = BoolArgumentType.bool().parse(stringReader)
 
     override fun getSuggestions(
-        context: CommandContext<ServerCommandSource>?,
-        builder: SuggestionsBuilder?
-    ): CompletableFuture<Suggestions> =CommandSource.suggestMatching(setOf("true", "false"), builder)
+        context: CommandContext<ServerCommandSource>,
+        builder: SuggestionsBuilder
+    ): CompletableFuture<Suggestions> = CommandSource.suggestMatching(setOf("true", "false"), builder)
 }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
@@ -208,6 +208,10 @@ object DatabaseManager {
             query.andWhere { Tables.Actions.timestamp.greaterEq(params.after) }
         }
 
+        if (params.rolledBack != null) {
+            query.andWhere { Tables.Actions.rolledBack.eq(params.rolledBack) }
+        }
+
         addParameters(
             query,
             params.sourceNames,

--- a/src/main/kotlin/com/github/quiltservertools/ledger/network/Networking.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/network/Networking.kt
@@ -20,7 +20,7 @@ import net.minecraft.util.Identifier
 object Networking {
     // List of players who have a compatible client mod
     private var networkedPlayers = mutableSetOf<ServerPlayerEntity>()
-    const val protocolVersion = 2
+    const val PROTOCOL_VERSION = 3
 
     init {
         if (config[NetworkingSpec.networking]) {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/HandshakePacketReceiver.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/HandshakePacketReceiver.kt
@@ -40,24 +40,24 @@ class HandshakePacketReceiver : Receiver {
             val modVersion = info.get().version
             val ledgerVersion = FabricLoader.getInstance().getModContainer(
                 Ledger.MOD_ID).get().metadata.version.friendlyString
-            if (Networking.protocolVersion == info.get().protocolVersion) {
+            if (Networking.PROTOCOL_VERSION == info.get().protocolVersion) {
                 logInfo("${player.name.string} joined the server with a Ledger compatible client mod")
                 logInfo("Mod: $modid, Version: $modVersion")
 
                 // Player has networking permissions so we send a response
                 val packet = HandshakePacket()
-                packet.populate(HandshakeContent(Networking.protocolVersion, ledgerVersion, ActionRegistry.getTypes().toList()))
+                packet.populate(HandshakeContent(Networking.PROTOCOL_VERSION, ledgerVersion, ActionRegistry.getTypes().toList()))
                 ServerPlayNetworking.send(player, packet.channel, packet.buf)
                 player.enableNetworking()
             } else {
                 player.sendMessage(
                     Text.translatable(
                         "text.ledger.network.protocols_mismatched",
-                        Networking.protocolVersion, info.get().protocolVersion
+                        Networking.PROTOCOL_VERSION, info.get().protocolVersion
                     ), false
                 )
                 logInfo("${player.name.string} joined the server with a Ledger compatible client mod, " +
-                        "but has a mismatched protocol: Ledger protocol version: ${Networking.protocolVersion}" +
+                        "but has a mismatched protocol: Ledger protocol version: ${Networking.PROTOCOL_VERSION}" +
                         ", Client mod protocol version ${info.get().protocolVersion}")
             }
         } else {


### PR DESCRIPTION
Adds a new boolean param (`rolledBack`) to allow filter by rollback status. This param is ignored in the query builder unless set.

Fixes #195 