### PR TITLE
Add timezone config option

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,9 @@ Found under `[search]`
 
 `purgePermissionLevel` [Default: 4] controls the permission level required to run the purge command
 
+`timeZone` [Default: "UTC"] sets the timezone to display timestamps in when hovered. 
+This uses the Java TimeZone format. You can provide offsets ("UTC", "UTC+3"), but the "continent/region" format is preferred. A full list can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
 ### Message theme
 
 Found under `[color]`
@@ -64,6 +67,8 @@ queueCheckDelaySec = 10
 pageSize = 8
 # Permission level for purge command
 purgePermissionLevel = 4
+# Time zone to display timestamps in. EX: "UTC", "UTC+1", "America/Los_Angeles"
+timeZone = "UTC"
 
 [color]
 # Colors in hex format

--- a/src/main/kotlin/com/github/quiltservertools/ledger/config/SearchSpec.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/config/SearchSpec.kt
@@ -1,8 +1,10 @@
 package com.github.quiltservertools.ledger.config
 
 import com.uchuhimo.konf.ConfigSpec
+import java.time.ZoneId
 
 object SearchSpec : ConfigSpec() {
     val pageSize by required<Int>()
     val purgePermissionLevel by required<Int>()
+    val timeZone by required<ZoneId>()
 }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/MessageUtils.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/MessageUtils.kt
@@ -1,17 +1,22 @@
 package com.github.quiltservertools.ledger.utility
 
+import com.github.quiltservertools.ledger.Ledger
 import com.github.quiltservertools.ledger.actionutils.SearchResults
+import com.github.quiltservertools.ledger.config.SearchSpec
 import com.github.quiltservertools.ledger.database.DatabaseManager
 import com.github.quiltservertools.ledger.network.Networking.hasNetworking
 import com.github.quiltservertools.ledger.network.packet.action.ActionPacket
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
 import net.minecraft.server.command.ServerCommandSource
-import net.minecraft.text.*
+import net.minecraft.text.ClickEvent
+import net.minecraft.text.HoverEvent
+import net.minecraft.text.MutableText
+import net.minecraft.text.Style
+import net.minecraft.text.Text
 import java.time.Duration
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
-import java.util.*
 import kotlin.time.ExperimentalTime
 import kotlin.time.toKotlinDuration
 
@@ -125,7 +130,7 @@ object MessageUtils {
         val message = Text.translatable("text.ledger.action_message.time_diff", text)
 
         val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
-        val timeMessage = formatter.format(time.atZone(TimeZone.getDefault().toZoneId())).literal()
+        val timeMessage = formatter.format(time.atZone(Ledger.config[SearchSpec.timeZone])).literal()
 
         message.styled {
             it.withHoverEvent(

--- a/src/main/resources/ledger.toml
+++ b/src/main/resources/ledger.toml
@@ -11,6 +11,8 @@ autoPurgeDays = -1
 pageSize = 8
 # Permission level for purge command
 purgePermissionLevel = 4
+# Time zone to display timestamps in (UTC, UTC+1, America/Los_Angeles)
+timeZone = "UTC"
 
 [color]
 # Colors in hex format


### PR DESCRIPTION
Adds `timeZone` to SearchSpec to configure how timestamps are formatted to user.

Could be cool to have this per user someday