### PR TITLE
Log Sign Editing and Waxing

### DIFF
--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/AbstractSignBlockMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/AbstractSignBlockMixin.java
@@ -18,7 +18,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(AbstractSignBlock.class)
-@Debug
 public class AbstractSignBlockMixin {
 
     /**
@@ -53,15 +52,11 @@ public class AbstractSignBlockMixin {
             Operation<Boolean> original
     ) {
 
-        BlockState oldState = signBlockEntity.getCachedState();
+        BlockState state = signBlockEntity.getCachedState();
         BlockPos pos = signBlockEntity.getPos();
 
         // a bad hack to copy the old sign block entity for rollbacks
-        @Nullable BlockEntity oldSignEntity = BlockEntity.createFromNbt(
-                pos,
-                oldState,
-                signBlockEntity.createNbtWithId()
-        );
+        @Nullable BlockEntity oldSignEntity = BlockEntity.createFromNbt(pos, state, signBlockEntity.createNbtWithId());
 
         boolean result = original.call(instance, world, signBlockEntity, front, player);
         if (result && oldSignEntity != null) {
@@ -69,8 +64,8 @@ public class AbstractSignBlockMixin {
                     .changeBlock(
                             world,
                             pos,
-                            oldState,
-                            world.getBlockState(pos),
+                            state,
+                            state, // the state doesn't update, the block entity does
                             oldSignEntity,
                             signBlockEntity,
                             player

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/AbstractSignBlockMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/AbstractSignBlockMixin.java
@@ -13,7 +13,6 @@ import net.minecraft.item.SignChangingItem;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
-import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/AbstractSignBlockMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/AbstractSignBlockMixin.java
@@ -1,0 +1,83 @@
+package com.github.quiltservertools.ledger.mixin.blocks.sign;
+
+import com.github.quiltservertools.ledger.callbacks.BlockChangeCallback;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.block.AbstractSignBlock;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.SignChangingItem;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Debug;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(AbstractSignBlock.class)
+@Debug
+public class AbstractSignBlockMixin {
+
+    /**
+     * Wraps the operation of item-based interactions with signs like waxing, dyeing, and using glow ink, with a
+     * block-change log action.
+     * <p>
+     * Uses a weird and probably bad hack that copies the NBT data of the sign into a new block entity instance so that
+     * the old data can be preserved for rollbacks.
+     *
+     * @param instance        The {@linkplain Item item} that is being used on the sign
+     * @param world           The world of the interaction
+     * @param signBlockEntity The sign block entity being interacted with
+     * @param front           Whether the interaction is happening on the front of the sign
+     * @param player          The player interacting with the sign
+     * @param original        The original {@link SignChangingItem#useOnSign(World, SignBlockEntity, boolean, PlayerEntity)}
+     *                        operation that this mixin wraps.
+     * @return Returns the result of calling {@code original} with this method's parameters.
+     */
+    @WrapOperation(
+            method = "onUse",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/item/SignChangingItem;useOnSign(Lnet/minecraft/world/World;Lnet/minecraft/block/entity/SignBlockEntity;ZLnet/minecraft/entity/player/PlayerEntity;)Z"
+            )
+    )
+    private boolean logSignItemInteraction(
+            SignChangingItem instance,
+            World world,
+            SignBlockEntity signBlockEntity,
+            boolean front,
+            PlayerEntity player,
+            Operation<Boolean> original
+    ) {
+
+        BlockState oldState = signBlockEntity.getCachedState();
+        BlockPos pos = signBlockEntity.getPos();
+
+        // a bad hack to copy the old sign block entity for rollbacks
+        @Nullable BlockEntity oldSignEntity = BlockEntity.createFromNbt(
+                pos,
+                oldState,
+                signBlockEntity.createNbtWithId()
+        );
+
+        boolean result = original.call(instance, world, signBlockEntity, front, player);
+        if (result && oldSignEntity != null) {
+            BlockChangeCallback.EVENT.invoker()
+                    .changeBlock(
+                            world,
+                            pos,
+                            oldState,
+                            world.getBlockState(pos),
+                            oldSignEntity,
+                            signBlockEntity,
+                            player
+                    );
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/SignBlockEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/SignBlockEntityMixin.java
@@ -1,0 +1,72 @@
+package com.github.quiltservertools.ledger.mixin.blocks.sign;
+
+import com.github.quiltservertools.ledger.Ledger;
+import com.github.quiltservertools.ledger.callbacks.BlockChangeCallback;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.block.entity.SignText;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.filter.FilteredMessage;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.UnaryOperator;
+
+@Mixin(SignBlockEntity.class)
+public abstract class SignBlockEntityMixin {
+
+    @WrapOperation(
+            method = "tryChangeText",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/entity/SignBlockEntity;changeText(Ljava/util/function/UnaryOperator;Z)Z"
+            )
+    )
+    private boolean logSignTextChange(
+            SignBlockEntity instance,
+            UnaryOperator<SignText> textChanger,
+            boolean front,
+            Operation<Boolean> original
+    ) {
+
+        BlockPos pos = instance.getPos();
+        BlockState state = instance.getCachedState();
+
+        // a bad hack to copy the old sign block entity for rollbacks
+        @Nullable BlockEntity oldSignEntity = BlockEntity.createFromNbt(pos, state, instance.createNbtWithId());
+
+        boolean result = original.call(instance, textChanger, front);
+        if (result && oldSignEntity != null) {
+
+            World world = instance.getWorld();
+            assert world != null : "World cannot be null, this is already in the target method";
+
+            UUID editorID = instance.getEditor();
+            PlayerEntity player = world.getPlayerByUuid(editorID);
+            assert player != null : "The editor must exist, this is already checked in target method";
+
+            BlockChangeCallback.EVENT.invoker()
+                    .changeBlock(
+                            world,
+                            pos,
+                            state,
+                            state, // the state doesn't update, the block entity does
+                            oldSignEntity,
+                            instance,
+                            player
+                    );
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/SignBlockEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/SignBlockEntityMixin.java
@@ -1,29 +1,37 @@
 package com.github.quiltservertools.ledger.mixin.blocks.sign;
 
-import com.github.quiltservertools.ledger.Ledger;
 import com.github.quiltservertools.ledger.callbacks.BlockChangeCallback;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import java.util.UUID;
+import java.util.function.UnaryOperator;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.SignBlockEntity;
 import net.minecraft.block.entity.SignText;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.server.filter.FilteredMessage;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.UnaryOperator;
 
 @Mixin(SignBlockEntity.class)
 public abstract class SignBlockEntityMixin {
 
+    /**
+     * Wraps the operation of sign text editing with signs with a block-change log action.
+     * <p>
+     * Uses a weird and probably bad hack that copies the NBT data of the sign into a new block entity instance so that
+     * the old data can be preserved for rollbacks.
+     *
+     * @param instance    The sign block entity being edited
+     * @param textChanger A parameter for the original operation
+     * @param front       Whether the interaction is happening on the front of the sign
+     * @param original    The original {@link SignBlockEntity#changeText(UnaryOperator, boolean)} operation that this
+     *                    mixin wraps.
+     * @return Returns the result of calling {@code original} with this method's parameters.
+     */
     @WrapOperation(
             method = "tryChangeText",
             at = @At(

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/BlockChangeActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/BlockChangeActionType.kt
@@ -23,7 +23,9 @@ open class BlockChangeActionType : AbstractActionType() {
     override fun rollback(server: MinecraftServer): Boolean {
         val world = server.getWorld(world)
         world?.setBlockState(pos, oldBlockState())
+
         world?.getBlockEntity(pos)?.readNbt(StringNbtReader.parse(extraData))
+        world?.chunkManager?.markForUpdate(pos)
 
         return true
     }

--- a/src/main/resources/ledger.mixins.json
+++ b/src/main/resources/ledger.mixins.json
@@ -71,6 +71,7 @@
         "blocks.lectern.LecternScreenHandlerMixin",
         "blocks.lectern.ScreenHandlerMixin",
         "blocks.sign.AbstractSignBlockMixin",
+        "blocks.sign.SignBlockEntityMixin",
         "entities.ArmorStandEntityMixin",
         "entities.CatEntityMixin",
         "entities.CreeperEntityMixin",

--- a/src/main/resources/ledger.mixins.json
+++ b/src/main/resources/ledger.mixins.json
@@ -70,6 +70,7 @@
         "blocks.lectern.LecternBlockMixin",
         "blocks.lectern.LecternScreenHandlerMixin",
         "blocks.lectern.ScreenHandlerMixin",
+        "blocks.sign.AbstractSignBlockMixin",
         "entities.ArmorStandEntityMixin",
         "entities.CatEntityMixin",
         "entities.CreeperEntityMixin",


### PR DESCRIPTION
Implements #214 

Adds logging for sign (and hanging sign) text editing and item-based interactions including waxing, dyeing, ink, and glow ink, with rollback support.

Editing signs mutates the block entity instance which makes it difficult to properly log for rollbacks. My solution is a bit of a hack that captures the old block entity data by copying the NBT data into a new block entity instance and then logging that copy as the old block entity. This seems to me to be the only way to do this, but I would definitely prefer something that doesn't involve direct NBT copying like this. 

Currently, this does not seem to work with restoring. However, when I looked into it, restoring block entity data seems to just be a missing feature in Ledger. Perhaps another PR could implement this, or I could look into creating a new action type for sign editing. Especially for text editing, it might be nice to see something like "old text" -> "new text" in the result, similar to what happens when you wax a copper block. The sign text might be a bit long for a single line in a chat message, though. 

There is also an issue where rolling back a sign does not cause it to immediately update its appearance. Its data does indeed change, and you can verify by checking with `/data` or by rejoining the server. I assume this is related to another issue where signs also appear blank after inspecting them with left-click. It might be fixable by sending some sort of block entity update packet to nearby players on restore, but that might incur some additional cost of iterating over all players to find the nearby ones many times (and of course, the cost of actually sending those packets). 

Let me know what you think :D 