### PR TITLE
Improve entity kill preview

### DIFF
--- a/src/main/java/com/github/quiltservertools/ledger/mixin/preview/EntityTrackerEntryAccessor.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/preview/EntityTrackerEntryAccessor.java
@@ -1,0 +1,14 @@
+package com.github.quiltservertools.ledger.mixin.preview;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.EntityTrackerEntry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(EntityTrackerEntry.class)
+public interface EntityTrackerEntryAccessor {
+
+    @Accessor
+    Entity getEntity();
+
+}

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/Preview.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/Preview.kt
@@ -3,14 +3,12 @@ package com.github.quiltservertools.ledger.actionutils
 import com.github.quiltservertools.ledger.actions.ActionType
 import com.github.quiltservertools.ledger.commands.subcommands.RestoreCommand
 import com.github.quiltservertools.ledger.commands.subcommands.RollbackCommand
+import com.github.quiltservertools.ledger.mixin.preview.EntityTrackerEntryAccessor
 import com.github.quiltservertools.ledger.utility.Context
 import com.github.quiltservertools.ledger.utility.TextColorPallet
-import java.util.*
 import net.minecraft.item.ItemStack
 import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket
-import net.minecraft.network.packet.s2c.play.BundleS2CPacket
-import net.minecraft.network.packet.s2c.play.EntitiesDestroyS2CPacket
-import net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket
+import net.minecraft.server.network.EntityTrackerEntry
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
 import net.minecraft.util.math.BlockPos
@@ -22,10 +20,13 @@ class Preview(
     private val type: Type
 ) {
     val positions = mutableSetOf<BlockPos>()
+
     // Preview entities that got spawned. Need to removed
-    val spawnedEntityIds = mutableSetOf<Int>()
+    val spawnedEntityTrackers = mutableSetOf<EntityTrackerEntry>()
+
     // Preview entities that got removed. Need to be spawned
-    val removedEntityUuids = mutableSetOf<UUID>()
+    val removedEntityTrackers = mutableSetOf<EntityTrackerEntry>()
+
     // Preview items that should be modified in screen handlers (true = added, false = removed)
     val modifiedItems = mutableMapOf<BlockPos, MutableList<Pair<ItemStack, Boolean>>>()
 
@@ -56,22 +57,21 @@ class Preview(
 
     private fun cleanup(player: ServerPlayerEntity) {
         // Cleanup preview entities, to keep client and server in sync
-        val destroyPackets = spawnedEntityIds.map {
-            EntitiesDestroyS2CPacket(it)
-        }
-        player.networkHandler.sendPacket(BundleS2CPacket(destroyPackets))
-
-        spawnedEntityIds.forEach {
-            player.networkHandler.sendPacket(EntitiesDestroyS2CPacket(it))
-        }
-        val spawnPackets = removedEntityUuids.mapNotNull {
-            val world = player.serverWorld
-            val entity = world?.getEntity(it)
-            entity?.let {
-                EntitySpawnS2CPacket(entity)
+        spawnedEntityTrackers.forEach {
+            if (!isEntityPresent(it)) {
+                it.stopTracking(player)
             }
         }
-        player.networkHandler.sendPacket(BundleS2CPacket(spawnPackets))
+        removedEntityTrackers.forEach {
+            if (isEntityPresent(it)) {
+                it.startTracking(player)
+            }
+        }
+    }
+
+    private fun isEntityPresent(entityTrackerEntry: EntityTrackerEntry): Boolean {
+        val entity = (entityTrackerEntry as EntityTrackerEntryAccessor).entity
+        return entity.world.getEntityById(entity.id) != null
     }
 
     fun apply(context: Context) {

--- a/src/main/resources/ledger.mixins.json
+++ b/src/main/resources/ledger.mixins.json
@@ -91,6 +91,7 @@
         "entities.VillagerEntityMixin",
         "entities.WolfEntityMixin",
         "preview.ChestBlockMixin",
+        "preview.EntityTrackerEntryAccessor",
         "preview.LockableContainerBlockEntityMixin",
         "preview.LootableContainerBlockEntityMixin",
         "preview.ServerPlayerEntityMixin"


### PR DESCRIPTION
Fixes `entity-kill` preview not showing equipment, datatracker values (eg. cat varient) and more ...
Uses vanilla `EntityTrackerEntry.startTracking()` to correctly send all required packets.