### PR TITLE
feat!: item components based item logging, standalone column `count` for items and events

### DIFF
--- a/src/main/java/com/github/quiltservertools/ledger/mixin/BucketDispenserBehaviorMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/BucketDispenserBehaviorMixin.java
@@ -29,7 +29,7 @@ public abstract class BucketDispenserBehaviorMixin extends ItemDispenserBehavior
     private void logFluidPickup(BlockPointer pointer, ItemStack stack, CallbackInfoReturnable<ItemStack> cir, @Local(argsOnly = true) ItemStack itemStack, @Local BlockPos pos, @Local BlockState blockState) {
         var world = pointer.world();
         if (!itemStack.isEmpty()) {
-            if (blockState.isLiquid() || blockState.isOf(Blocks.POWDER_SNOW)) {
+            if (!blockState.getFluidState().isEmpty() || blockState.isOf(Blocks.POWDER_SNOW)) {
                 BlockBreakCallback.EVENT.invoker().breakBlock(world, pos, blockState, world.getBlockEntity(pos), Sources.REDSTONE);
             } else {
                 BlockChangeCallback.EVENT.invoker().changeBlock(

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/NetherPortalMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/NetherPortalMixin.java
@@ -22,8 +22,8 @@ public abstract class NetherPortalMixin {
 
     @Inject(method = "method_30488", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldAccess;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z"))
     public void logPortalPlacement(BlockState state, BlockPos pos, CallbackInfo ci) {
-        if (this.world instanceof ServerWorld world) {
-            BlockPlaceCallback.EVENT.invoker().place(world, pos.toImmutable(), state, null, Sources.PORTAL);
+        if (this.world instanceof ServerWorld serverWorld) {
+            BlockPlaceCallback.EVENT.invoker().place(serverWorld, pos.toImmutable(), state, null, Sources.PORTAL);
         }
     }
 }

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/SlotMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/SlotMixin.java
@@ -27,7 +27,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Slot.class)
 public abstract class SlotMixin implements HandledSlot {
+    @Unique
     private ScreenHandler handler = null;
+    @Unique
     private ItemStack oldStack = null;
 
     @Shadow

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/SpongeBlockMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/SpongeBlockMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.block.SpongeBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -16,6 +17,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(SpongeBlock.class)
 public abstract class SpongeBlockMixin {
 
+    @Unique
     private BlockState oldBlockState;
 
     @Inject(method = "method_49829", at = @At(value = "INVOKE",

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/cauldron/CauldronBehaviorMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/cauldron/CauldronBehaviorMixin.java
@@ -2,6 +2,7 @@ package com.github.quiltservertools.ledger.mixin.blocks.cauldron;
 
 import com.github.quiltservertools.ledger.callbacks.BlockChangeCallback;
 import com.github.quiltservertools.ledger.utility.Sources;
+import java.util.function.Predicate;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.cauldron.CauldronBehavior;
@@ -13,11 +14,10 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.function.Predicate;
 
 @Mixin(CauldronBehavior.class)
 public interface CauldronBehaviorMixin {
@@ -50,6 +50,7 @@ public interface CauldronBehaviorMixin {
         ledgerLogFillCauldron(world, pos, state, world.getBlockState(pos), player);
     }
 
+    @Unique
     private static void ledgerLogDrainCauldron(World world, BlockPos pos, BlockState oldState, PlayerEntity player) {
         BlockChangeCallback.EVENT.invoker().changeBlock(
                 world,
@@ -62,6 +63,7 @@ public interface CauldronBehaviorMixin {
                 player);
     }
 
+    @Unique
     private static void ledgerLogFillCauldron(World world, BlockPos pos, BlockState oldState, BlockState newState, PlayerEntity player) {
         BlockChangeCallback.EVENT.invoker().changeBlock(
                 world,

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/cauldron/LeveledCauldronBlockMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/cauldron/LeveledCauldronBlockMixin.java
@@ -11,6 +11,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -18,6 +19,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(LeveledCauldronBlock.class)
 public abstract class LeveledCauldronBlockMixin {
 
+    @Unique
     private static PlayerEntity playerEntity;
 
     @Inject(method = "decrementFluidLevel", at = @At(value = "INVOKE",

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/SignBlockEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/SignBlockEntityMixin.java
@@ -3,6 +3,8 @@ package com.github.quiltservertools.ledger.mixin.blocks.sign;
 import com.github.quiltservertools.ledger.callbacks.BlockChangeCallback;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import java.util.UUID;
+import java.util.function.UnaryOperator;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.SignBlockEntity;
@@ -14,9 +16,6 @@ import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-
-import java.util.UUID;
-import java.util.function.UnaryOperator;
 
 @Mixin(SignBlockEntity.class)
 public abstract class SignBlockEntityMixin {
@@ -49,6 +48,7 @@ public abstract class SignBlockEntityMixin {
     ) {
 
         World world = instance.getWorld();
+        assert world != null;
         DynamicRegistryManager registryManager = world.getRegistryManager();
         BlockPos pos = instance.getPos();
         BlockState state = instance.getCachedState();
@@ -58,8 +58,6 @@ public abstract class SignBlockEntityMixin {
 
         boolean result = original.call(instance, textChanger, front);
         if (result && oldSignEntity != null) {
-
-            assert world != null : "World cannot be null, this is already in the target method";
 
             UUID editorID = instance.getEditor();
             PlayerEntity player = world.getPlayerByUuid(editorID);

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/entities/RavagerEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/entities/RavagerEntityMixin.java
@@ -1,20 +1,27 @@
 package com.github.quiltservertools.ledger.mixin.entities;
 
 import com.github.quiltservertools.ledger.callbacks.BlockBreakCallback;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.mob.RavagerEntity;
+import net.minecraft.entity.raid.RaiderEntity;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(RavagerEntity.class)
-public abstract class RavagerEntityMixin {
+public abstract class RavagerEntityMixin extends RaiderEntity {
+    protected RavagerEntityMixin(EntityType<? extends RaiderEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
     @ModifyArgs(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;breakBlock(Lnet/minecraft/util/math/BlockPos;ZLnet/minecraft/entity/Entity;)Z"))
     public void logRavagerBreakingLeaves(Args args) {
         BlockPos pos = args.get(0);
-        var world = ((RavagerEntity) (Object) this).getWorld();
+        var world = this.getWorld();
         BlockBreakCallback.EVENT.invoker().breakBlock(world, pos, world.getBlockState(pos), world.getBlockEntity(pos), Registries.ENTITY_TYPE.getId(((RavagerEntity) (Object) this).getType()).getPath());
     }
 }

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/preview/ChestBlockMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/preview/ChestBlockMixin.java
@@ -15,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(targets = "net/minecraft/block/ChestBlock$2$1")
 public abstract class ChestBlockMixin {
 
+    // fixme
     @Shadow
     ChestBlockEntity field_17358;
 
@@ -24,6 +25,8 @@ public abstract class ChestBlockMixin {
     )
     private void addPositionContext(int i, PlayerInventory playerInventory, PlayerEntity playerEntity, CallbackInfoReturnable<ScreenHandler> cir) {
         ScreenHandler screenHandler = cir.getReturnValue();
+
+
         if (screenHandler != null) {
             ((HandlerWithContext) screenHandler).setPos(this.field_17358.getPos());
         }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/Ledger.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/Ledger.kt
@@ -39,7 +39,7 @@ import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import java.nio.file.Files
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.minutes
@@ -70,7 +70,7 @@ object Ledger : DedicatedServerModInitializer, CoroutineScope {
         if (!Files.exists(FabricLoader.getInstance().configDir.resolve(CONFIG_PATH))) {
             logInfo("No config file, Creating")
             Files.copy(
-                FabricLoader.getInstance().getModContainer(MOD_ID).get().getPath(CONFIG_PATH),
+                FabricLoader.getInstance().getModContainer(MOD_ID).get().findPath(CONFIG_PATH).get(),
                 FabricLoader.getInstance().configDir.resolve(CONFIG_PATH)
             )
         }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/Ledger.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/Ledger.kt
@@ -112,6 +112,7 @@ object Ledger : DedicatedServerModInitializer, CoroutineScope {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun serverStopped(server: MinecraftServer) {
         runBlocking {
             try {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/AbstractActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/AbstractActionType.kt
@@ -31,7 +31,9 @@ abstract class AbstractActionType : ActionType {
     override var sourceName: String = Sources.UNKNOWN
     override var sourceProfile: GameProfile? = null
     override var extraData: String? = null
+    override var itemData: String? = null
     override var rolledBack: Boolean = false
+    override var count: Int = 1
 
     override fun rollback(server: MinecraftServer): Boolean = false
     override fun previewRollback(preview: Preview, player: ServerPlayerEntity) = Unit

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ActionType.kt
@@ -25,7 +25,9 @@ interface ActionType {
     var sourceName: String
     var sourceProfile: GameProfile?
     var extraData: String?
+    var itemData: String?
     var rolledBack: Boolean
+    var count: Int
 
     fun rollback(server: MinecraftServer): Boolean
     fun restore(server: MinecraftServer): Boolean

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemChangeActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemChangeActionType.kt
@@ -27,7 +27,9 @@ import net.minecraft.text.Text
 import net.minecraft.util.Util
 import net.minecraft.util.math.BlockPos
 
-abstract class ItemChangeActionType : AbstractActionType() {
+open class ItemChangeActionType : AbstractActionType() {
+    override val identifier: String = "item-change"
+    
     override fun getTranslationType(): String {
         val item = Registries.ITEM.get(objectIdentifier)
         return if (item is BlockItem && item !is AliasedBlockItem) {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemDropActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemDropActionType.kt
@@ -59,8 +59,8 @@ open class ItemDropActionType : AbstractActionType() {
     override fun rollback(server: MinecraftServer): Boolean {
         val world = server.getWorld(world)
 
-        val newEntity = StringNbtReader.parse(objectState)
-        val uuid = newEntity!!.getUuid(UUID) ?: return false
+        val newEntityNbt = StringNbtReader.parse(objectState)
+        val uuid = newEntityNbt!!.getUuid(UUID) ?: return false
         val entity = world?.getEntity(uuid)
 
         if (entity != null) {
@@ -73,14 +73,14 @@ open class ItemDropActionType : AbstractActionType() {
     override fun restore(server: MinecraftServer): Boolean {
         val world = server.getWorld(world)
 
-        val newEntity = StringNbtReader.parse(objectState)
-        val uuid = newEntity!!.getUuid(UUID) ?: return false
+        val newEntityNbt = StringNbtReader.parse(objectState)
+        val uuid = newEntityNbt!!.getUuid(UUID) ?: return false
         val entity = world?.getEntity(uuid)
 
         if (entity == null) {
-            val entity = ItemEntity(EntityType.ITEM, world)
-            entity.readNbt(newEntity)
-            world?.spawnEntity(entity)
+            val newEntity = ItemEntity(EntityType.ITEM, world)
+            newEntity.readNbt(newEntityNbt)
+            world?.spawnEntity(newEntity)
         }
         return true
     }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemDropActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemDropActionType.kt
@@ -59,8 +59,8 @@ open class ItemDropActionType : AbstractActionType() {
     override fun rollback(server: MinecraftServer): Boolean {
         val world = server.getWorld(world)
 
-        val newEntityNbt = StringNbtReader.parse(objectState)
-        val uuid = newEntityNbt!!.getUuid(UUID) ?: return false
+        val newEntity = StringNbtReader.parse(objectState)
+        val uuid = newEntity!!.getUuid(UUID) ?: return false
         val entity = world?.getEntity(uuid)
 
         if (entity != null) {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemInsertActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemInsertActionType.kt
@@ -4,6 +4,7 @@ import com.github.quiltservertools.ledger.actionutils.Preview
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.network.ServerPlayerEntity
 
+@Deprecated("")
 class ItemInsertActionType : ItemChangeActionType() {
     override val identifier: String = "item-insert"
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemPickUpActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemPickUpActionType.kt
@@ -59,14 +59,14 @@ open class ItemPickUpActionType : AbstractActionType() {
     override fun rollback(server: MinecraftServer): Boolean {
         val world = server.getWorld(world)
 
-        val oldEntity = StringNbtReader.parse(oldObjectState)
-        val uuid = oldEntity!!.getUuid(UUID) ?: return false
+        val oldEntityNbt = StringNbtReader.parse(oldObjectState)
+        val uuid = oldEntityNbt!!.getUuid(UUID) ?: return false
         val entity = world?.getEntity(uuid)
 
         if (entity == null) {
-            val entity = ItemEntity(EntityType.ITEM, world)
-            entity.readNbt(oldEntity)
-            world?.spawnEntity(entity)
+            val oldEntity = ItemEntity(EntityType.ITEM, world)
+            oldEntity.readNbt(oldEntityNbt)
+            world?.spawnEntity(oldEntity)
         }
         return true
     }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemRemoveActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemRemoveActionType.kt
@@ -4,6 +4,7 @@ import com.github.quiltservertools.ledger.actionutils.Preview
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.network.ServerPlayerEntity
 
+@Deprecated("")
 class ItemRemoveActionType : ItemChangeActionType() {
     override val identifier: String = "item-remove"
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
@@ -15,12 +15,15 @@ import com.github.quiltservertools.ledger.utility.Sources
 import net.minecraft.block.BlockState
 import net.minecraft.block.Blocks
 import net.minecraft.block.entity.BlockEntity
+import net.minecraft.component.ComponentChanges
 import net.minecraft.entity.Entity
 import net.minecraft.entity.ItemEntity
 import net.minecraft.entity.damage.DamageSource
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NbtCompound
+import net.minecraft.nbt.NbtElement
+import net.minecraft.nbt.NbtOps
 import net.minecraft.registry.Registries
 import net.minecraft.util.math.BlockPos
 import net.minecraft.world.World
@@ -193,7 +196,14 @@ object ActionFactory {
         action.world = world.registryKey.value
         action.objectIdentifier = Registries.ITEM.getId(stack.item)
         action.sourceName = source
-        action.extraData = stack.encode(world.registryManager)?.asString()
+        if (!stack.componentChanges.isEmpty) {
+            val element = ComponentChanges.CODEC.encodeStart(
+                world.registryManager.getOps(NbtOps.INSTANCE),
+                stack.componentChanges
+            ).getOrThrow()
+            action.itemData = element?.asString()
+        }
+        action.count = stack.count
     }
 
     fun entityKillAction(world: World, pos: BlockPos, entity: Entity, cause: DamageSource): EntityKillActionType {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
@@ -138,6 +138,7 @@ object ActionFactory {
     ): ItemChangeActionType {
         val action = ItemChangeActionType()
         setItemData(action, pos, world, stack, Sources.PLAYER)
+        action.count = -stack.count
         action.sourceProfile = source.gameProfile
 
         return action

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
@@ -6,10 +6,9 @@ import com.github.quiltservertools.ledger.actions.BlockChangeActionType
 import com.github.quiltservertools.ledger.actions.BlockPlaceActionType
 import com.github.quiltservertools.ledger.actions.EntityChangeActionType
 import com.github.quiltservertools.ledger.actions.EntityKillActionType
+import com.github.quiltservertools.ledger.actions.ItemChangeActionType
 import com.github.quiltservertools.ledger.actions.ItemDropActionType
-import com.github.quiltservertools.ledger.actions.ItemInsertActionType
 import com.github.quiltservertools.ledger.actions.ItemPickUpActionType
-import com.github.quiltservertools.ledger.actions.ItemRemoveActionType
 import com.github.quiltservertools.ledger.utility.NbtUtils
 import com.github.quiltservertools.ledger.utility.Sources
 import net.minecraft.block.BlockState
@@ -22,7 +21,6 @@ import net.minecraft.entity.damage.DamageSource
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NbtCompound
-import net.minecraft.nbt.NbtElement
 import net.minecraft.nbt.NbtOps
 import net.minecraft.registry.Registries
 import net.minecraft.util.math.BlockPos
@@ -102,9 +100,10 @@ object ActionFactory {
         action.extraData = entity?.createNbt(world.registryManager)?.asString()
     }
 
-    fun itemInsertAction(world: World, stack: ItemStack, pos: BlockPos, source: String): ItemInsertActionType {
-        val action = ItemInsertActionType()
+    fun itemInsertAction(world: World, stack: ItemStack, pos: BlockPos, source: String): ItemChangeActionType {
+        val action = ItemChangeActionType()
         setItemData(action, pos, world, stack, source)
+        action.count = stack.count
 
         return action
     }
@@ -114,17 +113,19 @@ object ActionFactory {
         stack: ItemStack,
         pos: BlockPos,
         source: PlayerEntity
-    ): ItemInsertActionType {
-        val action = ItemInsertActionType()
+    ): ItemChangeActionType {
+        val action = ItemChangeActionType()
         setItemData(action, pos, world, stack, Sources.PLAYER)
+        action.count = stack.count
         action.sourceProfile = source.gameProfile
 
         return action
     }
 
-    fun itemRemoveAction(world: World, stack: ItemStack, pos: BlockPos, source: String): ItemRemoveActionType {
-        val action = ItemRemoveActionType()
+    fun itemRemoveAction(world: World, stack: ItemStack, pos: BlockPos, source: String): ItemChangeActionType {
+        val action = ItemChangeActionType()
         setItemData(action, pos, world, stack, source)
+        action.count = -stack.count
 
         return action
     }
@@ -134,8 +135,8 @@ object ActionFactory {
         stack: ItemStack,
         pos: BlockPos,
         source: PlayerEntity
-    ): ItemRemoveActionType {
-        val action = ItemRemoveActionType()
+    ): ItemChangeActionType {
+        val action = ItemChangeActionType()
         setItemData(action, pos, world, stack, Sources.PLAYER)
         action.sourceProfile = source.gameProfile
 
@@ -203,7 +204,6 @@ object ActionFactory {
             ).getOrThrow()
             action.itemData = element?.asString()
         }
-        action.count = stack.count
     }
 
     fun entityKillAction(world: World, pos: BlockPos, entity: Entity, cause: DamageSource): EntityKillActionType {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/api/ExtensionManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/api/ExtensionManager.kt
@@ -26,6 +26,7 @@ object ExtensionManager {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     internal fun serverStarting(server: MinecraftServer) {
         extensions.forEach {
             if (it is DatabaseExtension) {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
@@ -224,7 +224,12 @@ object SearchParamArgument {
             context: CommandContext<ServerCommandSource>,
             builder: SuggestionsBuilder
         ): CompletableFuture<Suggestions> {
-            val builder = if (builder.remaining.startsWith("!")) builder.createOffset(builder.start + 1) else builder
+            @Suppress("NAME_SHADOWING")
+            val builder = if (builder.remaining.startsWith("!")) {
+                builder.createOffset(builder.start + 1)
+            } else {
+                builder
+            }
             return super.listSuggestions(context, builder)
         }
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/ActionQueueService.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/ActionQueueService.kt
@@ -44,7 +44,8 @@ object ActionQueueService {
             if (it !is ItemChangeActionType) return@removeIf false
             val list = containerMap.computeIfAbsent(it.pos) { mutableListOf() }
             val action = list.firstOrNull { other ->
-                other.itemData == it.itemData && other.objectIdentifier == it.objectIdentifier
+                other.itemData == it.itemData && other.objectIdentifier == it.objectIdentifier &&
+                        it.sourceName == other.sourceName && it.sourceProfile == other.sourceProfile
             }
             if (action != null) {
                 action.count += it.count
@@ -54,6 +55,7 @@ object ActionQueueService {
                 false
             }
         }
+        batch.removeIf { it is ItemChangeActionType && it.count == 0 } // remove empty events
 
         DatabaseManager.logActionBatch(batch)
     }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
@@ -82,9 +82,11 @@ object DatabaseManager {
 
     private fun getDefaultDatasource(): DataSource {
         val dbFilepath = config.getDatabasePath().resolve("ledger.sqlite").pathString
-        return SQLiteDataSource(SQLiteConfig().apply {
+        return SQLiteDataSource(
+            SQLiteConfig().apply {
             setJournalMode(SQLiteConfig.JournalMode.WAL)
-        }).apply {
+            }
+        ).apply {
             url = "jdbc:sqlite:$dbFilepath"
         }
     }
@@ -457,7 +459,8 @@ object DatabaseManager {
             .innerJoin(
                 Tables.oldObjectTable,
                 { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] })
+                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
+            )
             .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
             .innerJoin(Tables.Sources)
             .selectAll()
@@ -499,7 +502,8 @@ object DatabaseManager {
             .innerJoin(
                 Tables.oldObjectTable,
                 { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] })
+                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
+            )
             .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
             .innerJoin(Tables.Sources)
             .selectAll()
@@ -520,7 +524,8 @@ object DatabaseManager {
             .innerJoin(
                 Tables.oldObjectTable,
                 { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] })
+                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
+            )
             .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
             .innerJoin(Tables.Sources)
             .selectAll()
@@ -548,7 +553,8 @@ object DatabaseManager {
             .innerJoin(
                 Tables.oldObjectTable,
                 { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] })
+                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
+            )
             .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
             .innerJoin(Tables.Sources)
             .selectAll()
@@ -619,7 +625,6 @@ object DatabaseManager {
 
     private fun getOrCreateSourceId(source: String): Int =
         getOrCreateObjectId(source, cache.sourceKeys, Tables.Source, Tables.Sources, Tables.Sources.name)
-
 
     private fun getOrCreateActionId(actionTypeId: String): Int =
         getOrCreateObjectId(

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
@@ -523,7 +523,6 @@ object DatabaseManager {
         .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
         .innerJoin(Tables.Sources)
 
-
     private fun Transaction.selectAndRestoreActions(params: ActionSearchParams): MutableList<ActionType> {
         val actions = mutableListOf<ActionType>()
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
@@ -186,6 +186,7 @@ object DatabaseManager {
             }
             type.extraData = action[Tables.Actions.extraData]
             type.rolledBack = action[Tables.Actions.rolledBack]
+            type.itemData = action[Tables.Actions.itemData]
 
             actions.add(type)
         }
@@ -427,6 +428,7 @@ object DatabaseManager {
             this[Tables.Actions.sourceName] = getOrCreateSourceId(action.sourceName)
             this[Tables.Actions.sourcePlayer] = action.sourceProfile?.let { getOrCreatePlayerId(it.id) }
             this[Tables.Actions.extraData] = action.extraData
+            this[Tables.Actions.itemData] = action.itemData
         }
     }
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/Tables.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/Tables.kt
@@ -68,6 +68,7 @@ object Tables {
         val sourcePlayer = optReference("player_id", Players.id).index()
         val extraData = text("extra_data").nullable()
         val itemData = text("item_data").nullable()
+        val count = integer("count")
         val rolledBack = bool("rolled_back").clientDefault { false }
 
         init {
@@ -90,6 +91,7 @@ object Tables {
         var sourcePlayer by Player optionalReferencedOn Actions.sourcePlayer
         var extraData by Actions.extraData
         var itemData by Actions.itemData
+        var count by Actions.count
         var rolledBack by Actions.rolledBack
 
         companion object : IntEntityClass<Action>(Actions)

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/Tables.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/Tables.kt
@@ -1,5 +1,6 @@
 package com.github.quiltservertools.ledger.database
 
+import com.github.quiltservertools.ledger.actions.ActionType
 import net.minecraft.util.Identifier
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
@@ -67,6 +68,7 @@ object Tables {
         val sourceName = reference("source", Sources.id).index()
         val sourcePlayer = optReference("player_id", Players.id).index()
         val extraData = text("extra_data").nullable()
+        val itemData = text("item_data").nullable()
         val rolledBack = bool("rolled_back").clientDefault { false }
 
         init {
@@ -88,6 +90,7 @@ object Tables {
         var sourceName by Source referencedOn Actions.sourceName
         var sourcePlayer by Player optionalReferencedOn Actions.sourcePlayer
         var extraData by Actions.extraData
+        var itemData by Actions.itemData
         var rolledBack by Actions.rolledBack
 
         companion object : IntEntityClass<Action>(Actions)

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/Tables.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/Tables.kt
@@ -1,6 +1,5 @@
 package com.github.quiltservertools.ledger.database
 
-import com.github.quiltservertools.ledger.actions.ActionType
 import net.minecraft.util.Identifier
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass

--- a/src/main/kotlin/com/github/quiltservertools/ledger/listeners/BlockEventListener.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/listeners/BlockEventListener.kt
@@ -55,6 +55,7 @@ fun onBlockBreak(
     ActionQueueService.addToQueue(action)
 }
 
+@Suppress("UNUSED_PARAMETER")
 fun onBlockChange(
     world: World,
     pos: BlockPos,

--- a/src/main/kotlin/com/github/quiltservertools/ledger/listeners/PlayerEventListener.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/listeners/PlayerEventListener.kt
@@ -19,7 +19,6 @@ import net.minecraft.block.BlockState
 import net.minecraft.block.entity.BlockEntity
 import net.minecraft.entity.ItemEntity
 import net.minecraft.entity.player.PlayerEntity
-import net.minecraft.item.ItemPlacementContext
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.network.ServerPlayNetworkHandler
 import net.minecraft.util.ActionResult
@@ -39,10 +38,12 @@ fun registerPlayerListeners() {
     ItemDropCallback.EVENT.register(::onItemDrop)
 }
 
+@Suppress("UNUSED_PARAMETER")
 fun onLeave(handler: ServerPlayNetworkHandler, server: MinecraftServer) {
     handler.player.disableNetworking()
 }
 
+@Suppress("UNUSED_PARAMETER")
 private fun onUseBlock(
     player: PlayerEntity,
     world: World,
@@ -57,6 +58,7 @@ private fun onUseBlock(
     return ActionResult.PASS
 }
 
+@Suppress("UNUSED_PARAMETER")
 private fun onBlockAttack(
     player: PlayerEntity,
     world: World,
@@ -74,29 +76,11 @@ private fun onBlockAttack(
     return ActionResult.PASS
 }
 
+@Suppress("UNUSED_PARAMETER")
 private fun onJoin(networkHandler: ServerPlayNetworkHandler, packetSender: PacketSender, server: MinecraftServer) {
     Ledger.launch {
         DatabaseManager.logPlayer(networkHandler.player.uuid, networkHandler.player.nameForScoreboard)
     }
-}
-
-private fun onBlockPlace(
-    world: World,
-    player: PlayerEntity,
-    pos: BlockPos,
-    state: BlockState,
-    context: ItemPlacementContext?,
-    blockEntity: BlockEntity?
-) {
-    ActionQueueService.addToQueue(
-        ActionFactory.blockPlaceAction(
-            world,
-            pos,
-            state,
-            player,
-            blockEntity
-        )
-    )
 }
 
 private fun onBlockBreak(

--- a/src/main/kotlin/com/github/quiltservertools/ledger/listeners/WorldEventListener.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/listeners/WorldEventListener.kt
@@ -20,6 +20,7 @@ fun registerWorldEventListeners() {
     ServerWorldEvents.LOAD.register(::onWorldLoad)
 }
 
+@Suppress("UNUSED_PARAMETER")
 fun onWorldLoad(server: MinecraftServer, world: ServerWorld) {
     Ledger.launch {
         DatabaseManager.registerWorld(world.registryKey.value)

--- a/src/main/kotlin/com/github/quiltservertools/ledger/registry/ActionRegistry.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/registry/ActionRegistry.kt
@@ -1,7 +1,16 @@
 package com.github.quiltservertools.ledger.registry
 
 import com.github.quiltservertools.ledger.Ledger
-import com.github.quiltservertools.ledger.actions.*
+import com.github.quiltservertools.ledger.actions.ActionType
+import com.github.quiltservertools.ledger.actions.BlockBreakActionType
+import com.github.quiltservertools.ledger.actions.BlockChangeActionType
+import com.github.quiltservertools.ledger.actions.BlockPlaceActionType
+import com.github.quiltservertools.ledger.actions.EntityChangeActionType
+import com.github.quiltservertools.ledger.actions.EntityKillActionType
+import com.github.quiltservertools.ledger.actions.ItemDropActionType
+import com.github.quiltservertools.ledger.actions.ItemInsertActionType
+import com.github.quiltservertools.ledger.actions.ItemPickUpActionType
+import com.github.quiltservertools.ledger.actions.ItemRemoveActionType
 import com.github.quiltservertools.ledger.database.DatabaseManager
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import it.unimi.dsi.fastutil.objects.ObjectSet
@@ -25,6 +34,7 @@ object ActionRegistry {
         }
     }
 
+    @Suppress("DEPRECATION")
     fun registerDefaultTypes() {
         registerActionType { BlockBreakActionType() }
         registerActionType { BlockPlaceActionType() }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/registry/ActionRegistry.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/registry/ActionRegistry.kt
@@ -7,6 +7,7 @@ import com.github.quiltservertools.ledger.actions.BlockChangeActionType
 import com.github.quiltservertools.ledger.actions.BlockPlaceActionType
 import com.github.quiltservertools.ledger.actions.EntityChangeActionType
 import com.github.quiltservertools.ledger.actions.EntityKillActionType
+import com.github.quiltservertools.ledger.actions.ItemChangeActionType
 import com.github.quiltservertools.ledger.actions.ItemDropActionType
 import com.github.quiltservertools.ledger.actions.ItemInsertActionType
 import com.github.quiltservertools.ledger.actions.ItemPickUpActionType
@@ -41,6 +42,7 @@ object ActionRegistry {
         registerActionType { BlockChangeActionType() }
         registerActionType { ItemInsertActionType() }
         registerActionType { ItemRemoveActionType() }
+        registerActionType { ItemChangeActionType() }
         registerActionType { ItemPickUpActionType() }
         registerActionType { ItemDropActionType() }
         registerActionType { EntityKillActionType() }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/Extensions.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/Extensions.kt
@@ -16,8 +16,8 @@ fun MutableText.appendWithSpace(text: Text) {
     this.append(" ".literal())
 }
 
-fun String.literal() = Text.literal(this)
-fun String.translate() = Text.translatable(this)
+fun String.literal() = Text.literal(this)!!
+fun String.translate() = Text.translatable(this)!!
 
 fun ServerCommandSource.hasPlayer() = this.entity is ServerPlayerEntity
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
@@ -18,6 +18,7 @@ import net.minecraft.util.Identifier
 const val ITEM_NBT_DATA_VERSION = 3817
 const val ITEM_COMPONENTS_DATA_VERSION = 3825
 
+const val COMPONENTS = "components" // ItemStack
 const val PROPERTIES = "Properties" // BlockState
 const val COUNT_PRE_1_20_5 = "Count" // ItemStack
 const val COUNT = "count" // ItemStack

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
@@ -2,6 +2,7 @@ package com.github.quiltservertools.ledger.utility
 
 import com.mojang.serialization.Dynamic
 import net.minecraft.block.BlockState
+import net.minecraft.component.ComponentChanges
 import net.minecraft.datafixer.Schemas
 import net.minecraft.datafixer.TypeReferences
 import net.minecraft.item.ItemStack
@@ -70,5 +71,10 @@ object NbtUtils {
         }
 
         return ItemStack.fromNbt(registries, itemTag).get()
+    }
+
+    fun componentsFromNbt(nbt: String): ComponentChanges {
+        val tag = StringNbtReader.parse(nbt)
+        return ComponentChanges.CODEC.parse(NbtOps.INSTANCE, tag.get(COMPONENTS)).orThrow
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,8 @@
     "depends": {
         "fabricloader": ">=0.15.10",
         "fabric": ">=${fabricApi}",
-        "fabric-language-kotlin": ">=${fabricKotlin}"
+        "fabric-language-kotlin": ">=${fabricKotlin}",
+        "minecraft": ">=${minecraft}"
     },
     "breaks": {
         "cardboard": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,8 +28,7 @@
     "depends": {
         "fabricloader": ">=0.15.10",
         "fabric": ">=${fabricApi}",
-        "fabric-language-kotlin": ">=${fabricKotlin}",
-        "minecraft": ">=${minecraft}"
+        "fabric-language-kotlin": ">=${fabricKotlin}"
     },
     "breaks": {
         "cardboard": "*"

--- a/src/testmod/java/com/github/quiltservertools/ledger/testmod/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/testmod/java/com/github/quiltservertools/ledger/testmod/mixin/ClientPlayerInteractionManagerMixin.java
@@ -1,9 +1,9 @@
 package com.github.quiltservertools.ledger.testmod.mixin;
 
 import com.github.quiltservertools.ledger.testmod.LedgerTest;
+import com.github.quiltservertools.ledger.testmod.commands.InspectCommand;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
-import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
@@ -11,7 +11,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import com.github.quiltservertools.ledger.testmod.commands.InspectCommand;
 
 @Mixin(ClientPlayerInteractionManager.class)
 public class ClientPlayerInteractionManagerMixin {
@@ -19,11 +18,11 @@ public class ClientPlayerInteractionManagerMixin {
         method = "interactBlock",
         at = @At(
             value = "INVOKE",
-            target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;)V"
+                target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;sendSequencedPacket(Lnet/minecraft/client/world/ClientWorld;Lnet/minecraft/client/network/SequencedPacketCreator;)V"
         ),
         cancellable = true
     )
-    private void onInteractBlock(ClientPlayerEntity player, ClientWorld world, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
+    private void onInteractBlock(ClientPlayerEntity player, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
         if (!InspectCommand.INSTANCE.getInspectOn())
             return;
 


### PR DESCRIPTION
In this PR:

- added column `itemData` for item components, `count` for item count
- turned `item-insert` and `item-remove` into one event: `item-change`
- for events in the queue, try to squash them into one event to reduce events logged