### PR TITLE
Fix itemstack count in 1.20.5 and higher

### DIFF
--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
@@ -82,9 +82,11 @@ object DatabaseManager {
 
     private fun getDefaultDatasource(): DataSource {
         val dbFilepath = config.getDatabasePath().resolve("ledger.sqlite").pathString
-        return SQLiteDataSource(SQLiteConfig().apply {
+        return SQLiteDataSource(
+            SQLiteConfig().apply {
             setJournalMode(SQLiteConfig.JournalMode.WAL)
-        }).apply {
+        }
+        ).apply {
             url = "jdbc:sqlite:$dbFilepath"
         }
     }
@@ -455,7 +457,8 @@ object DatabaseManager {
             .innerJoin(
                 Tables.oldObjectTable,
                 { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] })
+                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
+            )
             .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
             .innerJoin(Tables.Sources)
             .selectAll()
@@ -497,7 +500,8 @@ object DatabaseManager {
             .innerJoin(
                 Tables.oldObjectTable,
                 { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] })
+                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
+            )
             .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
             .innerJoin(Tables.Sources)
             .selectAll()
@@ -518,7 +522,8 @@ object DatabaseManager {
             .innerJoin(
                 Tables.oldObjectTable,
                 { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] })
+                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
+            )
             .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
             .innerJoin(Tables.Sources)
             .selectAll()
@@ -546,7 +551,8 @@ object DatabaseManager {
             .innerJoin(
                 Tables.oldObjectTable,
                 { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] })
+                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
+            )
             .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
             .innerJoin(Tables.Sources)
             .selectAll()
@@ -617,7 +623,6 @@ object DatabaseManager {
 
     private fun getOrCreateSourceId(source: String): Int =
         getOrCreateObjectId(source, cache.sourceKeys, Tables.Source, Tables.Sources, Tables.Sources.name)
-
 
     private fun getOrCreateActionId(actionTypeId: String): Int =
         getOrCreateObjectId(

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
@@ -17,10 +17,9 @@ import net.minecraft.util.Identifier
 const val ITEM_NBT_DATA_VERSION = 3817
 const val ITEM_COMPONENTS_DATA_VERSION = 3825
 
-const val COMPONENTS = "components" // ItemStack
 const val PROPERTIES = "Properties" // BlockState
+const val COUNT_PRE_1_20_5 = "Count" // ItemStack
 const val COUNT = "count" // ItemStack
-const val TAG = "tag" // ItemStack
 const val UUID = "UUID" // Entity
 
 object NbtUtils {
@@ -47,26 +46,18 @@ object NbtUtils {
 
     fun itemFromProperties(tag: String?, name: Identifier, registries: RegistryWrapper.WrapperLookup): ItemStack {
         val extraDataTag = StringNbtReader.parse(tag ?: "{}")
-        var itemTag: NbtElement
-        if (extraDataTag.contains(COMPONENTS)) {
-            itemTag = extraDataTag
-        } else {
-            itemTag = NbtCompound()
+        var itemTag = extraDataTag
+        if (!extraDataTag.contains(COUNT)) {
+            // 1.20.4 and lower (need data fixing)
             itemTag.putString("id", name.toString())
-            if (extraDataTag.contains(COUNT)) {
-                itemTag.putByte(COUNT, extraDataTag.getByte(COUNT))
-            } else {
-                itemTag.putByte(COUNT, 1)
+            if (!itemTag.contains(COUNT_PRE_1_20_5)) {
+                // Ledger ItemStack in 1.20.4 and earlier had "Count" omitted if it was 1
+                itemTag.putByte(COUNT_PRE_1_20_5, 1)
             }
-
-            if (extraDataTag.contains(TAG)) {
-                itemTag.put(TAG, extraDataTag.getCompound(TAG))
-
-                itemTag = Schemas.getFixer().update(
-                    TypeReferences.ITEM_STACK,
-                    Dynamic(NbtOps.INSTANCE, itemTag), ITEM_NBT_DATA_VERSION, ITEM_COMPONENTS_DATA_VERSION
-                ).cast(NbtOps.INSTANCE)
-            }
+            itemTag = Schemas.getFixer().update(
+                TypeReferences.ITEM_STACK,
+                Dynamic(NbtOps.INSTANCE, itemTag), ITEM_NBT_DATA_VERSION, ITEM_COMPONENTS_DATA_VERSION
+            ).cast(NbtOps.INSTANCE) as NbtCompound?
         }
 
         return ItemStack.fromNbt(registries, itemTag).get()

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
@@ -19,7 +19,7 @@ const val ITEM_COMPONENTS_DATA_VERSION = 3825
 
 const val COMPONENTS = "components" // ItemStack
 const val PROPERTIES = "Properties" // BlockState
-const val COUNT = "Count" // ItemStack
+const val COUNT = "count" // ItemStack
 const val TAG = "tag" // ItemStack
 const val UUID = "UUID" // Entity
 


### PR DESCRIPTION
Reworked item data fixing to yield correct 1.20.5+ item nbt for old and new entries. It broke because it didn't take into consideration that 1.20.5 changed the `Count` field to `count`
- 1.20.5+ (detected by presence of "count" field) are not modified
- 1.20.4-
  - Add `id` field (was omitted in 1.20.4 ledger stacks, because it can be extracted through object id)
  - Set `Count` to 1 if it is not present (was omitted in 1.20.4 ledger stacks, because non present indicated count 1)
  - Most importantly: Apply `ItemStackComponentizationFix`