### PR TITLE
Enforce specific selectors on rollback / restore

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -40,6 +40,8 @@ Found under `[search]`
 `timeZone` [Default: "UTC"] sets the timezone to display timestamps in when hovered. 
 This uses the Java TimeZone format. You can provide offsets ("UTC", "UTC+3"), but the "continent/region" format is preferred. A full list can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
+`maxRange` [Default: 100] controls the maximum range allowed in rollback / restore
+
 ### Message theme
 
 Found under `[color]`

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -43,8 +43,6 @@ Multiple Allowed - `No`
 Example - `range:5`
 
 This parameter allows you to filter your selection based on your location.
-This will not filter by your dimension, so you may still get results from other worlds.
-Use the [dimension parameter](#dimension) to filter by world.
 
 ## Source
 Key - `source:`  

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
@@ -22,6 +22,7 @@ import com.mojang.brigadier.suggestion.Suggestions
 import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import net.minecraft.server.command.CommandManager
 import net.minecraft.server.command.ServerCommandSource
+import net.minecraft.text.Text
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockBox
 import net.minecraft.util.math.BlockPos
@@ -190,7 +191,7 @@ object SearchParamArgument {
         val input = builder.remaining.lowercase()
         for (param in paramSuggesters.keys) {
             if (param.startsWith(input)) {
-                builder.suggest("$param:")
+                builder.suggest("$param:", Text.translatable("text.ledger.parameter.$param.description"))
             }
         }
         return builder

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PreviewCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PreviewCommand.kt
@@ -51,12 +51,10 @@ object PreviewCommand : BuildableCommand {
             .build()
     }
 
-    private fun preview(context: Context, params: ActionSearchParams?, type: Preview.Type): Int {
+    private fun preview(context: Context, params: ActionSearchParams, type: Preview.Type): Int {
         val source = context.source
         val player = source.playerOrThrow
-
-        if (params == null) return -1
-
+        params.ensureSpecific()
         Ledger.launch(Dispatchers.IO) {
             MessageUtils.warnBusy(source)
             val actions = DatabaseManager.previewActions(params, type)

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RestoreCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RestoreCommand.kt
@@ -6,7 +6,12 @@ import com.github.quiltservertools.ledger.commands.BuildableCommand
 import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
-import com.github.quiltservertools.ledger.utility.*
+import com.github.quiltservertools.ledger.utility.Context
+import com.github.quiltservertools.ledger.utility.LiteralNode
+import com.github.quiltservertools.ledger.utility.MessageUtils
+import com.github.quiltservertools.ledger.utility.TextColorPallet
+import com.github.quiltservertools.ledger.utility.launchMain
+import com.github.quiltservertools.ledger.utility.literal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.lucko.fabric.api.permissions.v0.Permissions
@@ -26,7 +31,7 @@ object RestoreCommand : BuildableCommand {
 
     fun restore(context: Context, params: ActionSearchParams): Int {
         val source = context.source
-
+        params.ensureSpecific()
         Ledger.launch(Dispatchers.IO) {
             MessageUtils.warnBusy(source)
             val actions = DatabaseManager.restoreActions(params)

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RollbackCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RollbackCommand.kt
@@ -6,7 +6,12 @@ import com.github.quiltservertools.ledger.commands.BuildableCommand
 import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
-import com.github.quiltservertools.ledger.utility.*
+import com.github.quiltservertools.ledger.utility.Context
+import com.github.quiltservertools.ledger.utility.LiteralNode
+import com.github.quiltservertools.ledger.utility.MessageUtils
+import com.github.quiltservertools.ledger.utility.TextColorPallet
+import com.github.quiltservertools.ledger.utility.launchMain
+import com.github.quiltservertools.ledger.utility.literal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.lucko.fabric.api.permissions.v0.Permissions
@@ -24,11 +29,9 @@ object RollbackCommand : BuildableCommand {
             .build()
     }
 
-    fun rollback(context: Context, params: ActionSearchParams?): Int {
+    fun rollback(context: Context, params: ActionSearchParams): Int {
         val source = context.source
-
-        if (params == null) return -1
-
+        params.ensureSpecific()
         Ledger.launch(Dispatchers.IO) {
             MessageUtils.warnBusy(source)
             val actions = DatabaseManager.rollbackActions(params)

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/SearchCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/SearchCommand.kt
@@ -28,10 +28,6 @@ object SearchCommand : BuildableCommand {
 
     private fun search(context: Context, params: ActionSearchParams): Int {
         val source = context.source
-        if (params.isEmpty()) {
-            source.sendError(Text.translatable("error.ledger.command.no_params"))
-            return -1
-        }
 
         Ledger.launch {
             Ledger.searchCache[source.name] = params

--- a/src/main/kotlin/com/github/quiltservertools/ledger/config/SearchSpec.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/config/SearchSpec.kt
@@ -7,4 +7,5 @@ object SearchSpec : ConfigSpec() {
     val pageSize by required<Int>()
     val purgePermissionLevel by required<Int>()
     val timeZone by required<ZoneId>()
+    val maxRange by required<Int>()
 }

--- a/src/main/resources/data/ledger/lang/en_us.json
+++ b/src/main/resources/data/ledger/lang/en_us.json
@@ -45,6 +45,9 @@
     "error.ledger.no_more_pages": "No more pages",
     "error.ledger.unknown_param": "Unknown parameter %s",
     "error.ledger.no_preview": "No current preview",
+    "error.ledger.unspecific.range": "Please specify a range.",
+    "error.ledger.unspecific.range_to_big": "The maximum range is %s.",
+    "error.ledger.unspecific.source_or_time": "Please specify a source or time (after).",
 
     "text.ledger.action.block-place": "placed",
     "text.ledger.action.block-break": "broke",
@@ -55,6 +58,15 @@
     "text.ledger.action.item-drop": "dropped",
     "text.ledger.action.entity-kill": "killed",
     "text.ledger.action.entity-change": "changed",
+
+    "text.ledger.parameter.action.description": "Filter by type of performed action.",
+    "text.ledger.parameter.after.description": "Filter by time (after the provided time).",
+    "text.ledger.parameter.before.description": "Filter by time (before the provided time). Usually you want to use after.",
+    "text.ledger.parameter.object.description": "Filter by matching an object. Could be a block, item or entity.",
+    "text.ledger.parameter.range.description": "Filter by location (square radius around your location).",
+    "text.ledger.parameter.rolledback.description": "Filter by rolled back state.",
+    "text.ledger.parameter.source.description": "Filter by source (player name or source with '@').",
+    "text.ledger.parameter.world.description": "Filter by provided dimension.",
 
     "text.ledger.network.protocols_mismatched": "Protocol versions mismatched: client mod is Ledger protocol version %d and the client version is %d",
     "text.ledger.network.no_mod_info": "Unable to determine mod information for your client mod",

--- a/src/main/resources/ledger.toml
+++ b/src/main/resources/ledger.toml
@@ -19,6 +19,8 @@ pageSize = 8
 purgePermissionLevel = 4
 # Time zone to display timestamps in (UTC, UTC+1, America/Los_Angeles)
 timeZone = "UTC"
+# Maximum range allowed in rollback / restore commands
+maxRange = 100
 
 [color]
 # Colors in hex format


### PR DESCRIPTION
- Rollbacks / restores (and preview) now require a range and (a source or a time) to prevent accidental global rollbacks.
- Command parameters can now be hovered for a simple description