### PR TITLE
Improve rollback / restore logic

### DIFF
--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/AbstractActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/AbstractActionType.kt
@@ -21,6 +21,7 @@ import java.time.Instant
 import kotlin.time.ExperimentalTime
 
 abstract class AbstractActionType : ActionType {
+    override var id: Int = -1
     override var timestamp: Instant = Instant.now()
     override var pos: BlockPos = BlockPos.ORIGIN
     override var world: Identifier? = null

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ActionType.kt
@@ -14,6 +14,7 @@ import java.time.Instant
 import kotlin.time.ExperimentalTime
 
 interface ActionType {
+    var id: Int
     val identifier: String
     var timestamp: Instant
     var pos: BlockPos

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemChangeActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemChangeActionType.kt
@@ -3,9 +3,11 @@ package com.github.quiltservertools.ledger.actions
 import com.github.quiltservertools.ledger.actionutils.Preview
 import com.github.quiltservertools.ledger.utility.NbtUtils
 import com.github.quiltservertools.ledger.utility.TextColorPallet
+import com.github.quiltservertools.ledger.utility.addItem
 import com.github.quiltservertools.ledger.utility.getOtherChestSide
 import com.github.quiltservertools.ledger.utility.getWorld
 import com.github.quiltservertools.ledger.utility.literal
+import com.github.quiltservertools.ledger.utility.removeMatchingItem
 import net.minecraft.block.Blocks
 import net.minecraft.block.ChestBlock
 import net.minecraft.block.InventoryProvider
@@ -108,15 +110,8 @@ abstract class ItemChangeActionType : AbstractActionType() {
 
         if (world != null) {
             val rollbackStack = getStack(server)
-
             if (inventory != null) {
-                for (i in 0 until inventory.size()) {
-                    val stack = inventory.getStack(i)
-                    if (ItemStack.areItemsEqual(stack, rollbackStack)) {
-                        inventory.setStack(i, ItemStack.EMPTY)
-                        return true
-                    }
-                }
+                return removeMatchingItem(rollbackStack, inventory)
             } else if (rollbackStack.isOf(Items.WRITABLE_BOOK) || rollbackStack.isOf(Items.WRITTEN_BOOK)) {
                 val blockEntity = world.getBlockEntity(pos)
                 if (blockEntity is LecternBlockEntity) {
@@ -136,15 +131,8 @@ abstract class ItemChangeActionType : AbstractActionType() {
 
         if (world != null) {
             val rollbackStack = getStack(server)
-
             if (inventory != null) {
-                for (i in 0 until inventory.size()) {
-                    val stack = inventory.getStack(i)
-                    if (stack.isEmpty) {
-                        inventory.setStack(i, rollbackStack)
-                        return true
-                    }
-                }
+                return addItem(rollbackStack, inventory)
             } else if (rollbackStack.isOf(Items.WRITABLE_BOOK) || rollbackStack.isOf(Items.WRITTEN_BOOK)) {
                 val blockEntity = world.getBlockEntity(pos)
                 if (blockEntity is LecternBlockEntity && !blockEntity.hasBook()) {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RestoreCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RestoreCommand.kt
@@ -6,7 +6,12 @@ import com.github.quiltservertools.ledger.commands.BuildableCommand
 import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
-import com.github.quiltservertools.ledger.utility.*
+import com.github.quiltservertools.ledger.utility.Context
+import com.github.quiltservertools.ledger.utility.LiteralNode
+import com.github.quiltservertools.ledger.utility.MessageUtils
+import com.github.quiltservertools.ledger.utility.TextColorPallet
+import com.github.quiltservertools.ledger.utility.launchMain
+import com.github.quiltservertools.ledger.utility.literal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.lucko.fabric.api.permissions.v0.Permissions
@@ -29,7 +34,7 @@ object RestoreCommand : BuildableCommand {
 
         Ledger.launch(Dispatchers.IO) {
             MessageUtils.warnBusy(source)
-            val actions = DatabaseManager.restoreActions(params)
+            val actions = DatabaseManager.selectRestore(params)
 
             if (actions.isEmpty()) {
                 source.sendError(Text.translatable("error.ledger.command.no_results"))
@@ -48,12 +53,16 @@ object RestoreCommand : BuildableCommand {
 
             context.source.world.launchMain {
                 val fails = HashMap<String, Int>()
-
+                val actionIds = HashSet<Int>()
                 for (action in actions) {
                     if (!action.restore(context.source.server)) {
                         fails[action.identifier] = fails.getOrPut(action.identifier) { 0 } + 1
+                    } else {
+                        actionIds.add(action.id)
                     }
-                    action.rolledBack = true
+                }
+                Ledger.launch(Dispatchers.IO) {
+                    DatabaseManager.restoreActions(actionIds)
                 }
 
                 for (entry in fails.entries) {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RollbackCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RollbackCommand.kt
@@ -6,7 +6,12 @@ import com.github.quiltservertools.ledger.commands.BuildableCommand
 import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
-import com.github.quiltservertools.ledger.utility.*
+import com.github.quiltservertools.ledger.utility.Context
+import com.github.quiltservertools.ledger.utility.LiteralNode
+import com.github.quiltservertools.ledger.utility.MessageUtils
+import com.github.quiltservertools.ledger.utility.TextColorPallet
+import com.github.quiltservertools.ledger.utility.launchMain
+import com.github.quiltservertools.ledger.utility.literal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.lucko.fabric.api.permissions.v0.Permissions
@@ -31,7 +36,7 @@ object RollbackCommand : BuildableCommand {
 
         Ledger.launch(Dispatchers.IO) {
             MessageUtils.warnBusy(source)
-            val actions = DatabaseManager.rollbackActions(params)
+            val actions = DatabaseManager.selectRollback(params)
 
             if (actions.isEmpty()) {
                 source.sendError(Text.translatable("error.ledger.command.no_results"))
@@ -50,12 +55,16 @@ object RollbackCommand : BuildableCommand {
 
             context.source.world.launchMain {
                 val fails = HashMap<String, Int>()
-
+                val actionIds = HashSet<Int>()
                 for (action in actions) {
                     if (!action.rollback(context.source.server)) {
                         fails[action.identifier] = fails.getOrPut(action.identifier) { 0 } + 1
+                    } else {
+                        actionIds.add(action.id)
                     }
-                    action.rolledBack = true
+                }
+                Ledger.launch(Dispatchers.IO) {
+                    DatabaseManager.rollbackActions(actionIds)
                 }
 
                 for (entry in fails.entries) {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
@@ -30,6 +30,7 @@ import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.Query
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.inSubQuery
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.lessEq
 import org.jetbrains.exposed.sql.SqlLogger
@@ -148,18 +149,49 @@ object DatabaseManager {
     }
 
     suspend fun rollbackActions(params: ActionSearchParams): List<ActionType> = execute {
-        return@execute selectAndRollbackActions(params)
+        val actions = selectRollback(params)
+        val actionIds = actions.map { it.id }.toSet()
+        rollbackActions(actionIds)
+        return@execute actions
+    }
+
+    suspend fun rollbackActions(actionIds: Set<Int>) = execute {
+        return@execute rollbackActions(actionIds)
     }
 
     suspend fun restoreActions(params: ActionSearchParams): List<ActionType> = execute {
-        return@execute selectAndRestoreActions(params)
+        val actions = selectRestore(params)
+        val actionIds = actions.map { it.id }.toSet()
+        restoreActions(actionIds)
+        return@execute actions
+    }
+
+    suspend fun restoreActions(actionIds: Set<Int>) = execute {
+        return@execute restoreActions(actionIds)
+    }
+
+    suspend fun selectRollback(params: ActionSearchParams): List<ActionType> = execute {
+        val query = buildQuery()
+            .where(buildQueryParams(params) and (Tables.Actions.rolledBack eq false))
+            .orderBy(Tables.Actions.id, SortOrder.DESC)
+        return@execute getActionsFromQuery(query)
+    }
+
+    suspend fun selectRestore(params: ActionSearchParams): List<ActionType> = execute {
+        val query = buildQuery()
+            .where(buildQueryParams(params) and (Tables.Actions.rolledBack eq true))
+            .orderBy(Tables.Actions.id, SortOrder.ASC)
+        return@execute getActionsFromQuery(query)
     }
 
     suspend fun previewActions(
         params: ActionSearchParams,
         type: Preview.Type
     ): List<ActionType> = execute {
-        return@execute selectActionsPreview(params, type)
+        when (type) {
+            Preview.Type.ROLLBACK -> return@execute selectRollback(params)
+            Preview.Type.RESTORE -> return@execute selectRestore(params)
+        }
     }
 
     private fun getActionsFromQuery(query: Query): List<ActionType> {
@@ -173,6 +205,7 @@ object DatabaseManager {
             }
 
             val type = typeSupplier.get()
+            type.id = action[Tables.Actions.id].value
             type.timestamp = action[Tables.Actions.timestamp]
             type.pos = BlockPos(action[Tables.Actions.x], action[Tables.Actions.y], action[Tables.Actions.z])
             type.world = Identifier.tryParse(action[Tables.Worlds.identifier])
@@ -448,23 +481,11 @@ object DatabaseManager {
 
     private fun Transaction.selectActionsSearch(params: ActionSearchParams, page: Int): SearchResults {
         val actions = mutableListOf<ActionType>()
-        var totalActions: Long
 
-        var query = Tables.Actions
-            .innerJoin(Tables.ActionIdentifiers)
-            .innerJoin(Tables.Worlds)
-            .leftJoin(Tables.Players)
-            .innerJoin(
-                Tables.oldObjectTable,
-                { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
-            )
-            .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
-            .innerJoin(Tables.Sources)
-            .selectAll()
+        var query = buildQuery()
             .andWhere { buildQueryParams(params) }
 
-        totalActions = countActions(params)
+        val totalActions: Long = countActions(params)
         if (totalActions == 0L) return SearchResults(actions, params, page, 0)
 
         query = query.orderBy(Tables.Actions.id, SortOrder.DESC)
@@ -485,15 +506,8 @@ object DatabaseManager {
         .andWhere { buildQueryParams(params) }
         .count()
 
-    private fun Transaction.selectActionsPreview(
-        params: ActionSearchParams,
-        type: Preview.Type
-    ): MutableList<ActionType> {
-        val actions = mutableListOf<ActionType>()
-
-        val isRestore = type == Preview.Type.RESTORE
-
-        val selectQuery = Tables.Actions
+    private fun Transaction.buildQuery(): Query {
+        return Tables.Actions
             .innerJoin(Tables.ActionIdentifiers)
             .innerJoin(Tables.Worlds)
             .leftJoin(Tables.Players)
@@ -505,68 +519,20 @@ object DatabaseManager {
             .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
             .innerJoin(Tables.Sources)
             .selectAll()
-            .andWhere { buildQueryParams(params) and (Tables.Actions.rolledBack eq isRestore) }
-            .orderBy(Tables.Actions.id, if (isRestore) SortOrder.ASC else SortOrder.DESC)
-        actions.addAll(getActionsFromQuery(selectQuery))
-
-        return actions
     }
 
-    private fun Transaction.selectAndRollbackActions(params: ActionSearchParams): MutableList<ActionType> {
-        val actions = mutableListOf<ActionType>()
-
-        val selectQuery = Tables.Actions
-            .innerJoin(Tables.ActionIdentifiers)
-            .innerJoin(Tables.Worlds)
-            .leftJoin(Tables.Players)
-            .innerJoin(
-                Tables.oldObjectTable,
-                { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
-            )
-            .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
-            .innerJoin(Tables.Sources)
-            .selectAll()
-            .andWhere { buildQueryParams(params) and (Tables.Actions.rolledBack eq false) }
-            .orderBy(Tables.Actions.id, SortOrder.DESC)
-        val actionIds = selectQuery.map { it[Tables.Actions.id] }
-            .toSet() // SQLite doesn't support update where so select by ID. Might not be as efficent
-        actions.addAll(getActionsFromQuery(selectQuery))
-
+    private fun Transaction.rollbackActions(actionIds: Set<Int>) {
         Tables.Actions
-            .update({ Tables.Actions.id inList actionIds and (Tables.Actions.rolledBack eq false) }) {
+            .update({ Tables.Actions.id inList actionIds }) {
                 it[rolledBack] = true
             }
-
-        return actions
     }
 
-    private fun Transaction.selectAndRestoreActions(params: ActionSearchParams): MutableList<ActionType> {
-        val actions = mutableListOf<ActionType>()
-
-        val selectQuery = Tables.Actions
-            .innerJoin(Tables.ActionIdentifiers)
-            .innerJoin(Tables.Worlds)
-            .leftJoin(Tables.Players)
-            .innerJoin(
-                Tables.oldObjectTable,
-                { Tables.Actions.oldObjectId },
-                { Tables.oldObjectTable[Tables.ObjectIdentifiers.id] }
-            )
-            .innerJoin(Tables.ObjectIdentifiers, { Tables.Actions.objectId }, { Tables.ObjectIdentifiers.id })
-            .innerJoin(Tables.Sources)
-            .selectAll()
-            .andWhere { buildQueryParams(params) and (Tables.Actions.rolledBack eq true) }
-            .orderBy(Tables.Actions.id, SortOrder.ASC)
-        val actionIds = selectQuery.map { it[Tables.Actions.id] }.toSet()
-        actions.addAll(getActionsFromQuery(selectQuery))
-
+    private fun Transaction.restoreActions(actionIds: Set<Int>) {
         Tables.Actions
-            .update({ Tables.Actions.id inList actionIds and (Tables.Actions.rolledBack eq true) }) {
+            .update({ Tables.Actions.id inList actionIds }) {
                 it[rolledBack] = false
             }
-
-        return actions
     }
 
     fun getKnownSources() =

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/ItemChangeLogic.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/ItemChangeLogic.kt
@@ -1,0 +1,78 @@
+package com.github.quiltservertools.ledger.utility
+
+import net.minecraft.inventory.Inventory
+import net.minecraft.item.ItemStack
+
+fun addItem(rollbackStack: ItemStack, inventory: Inventory): Boolean {
+    // Check if the inventory has enough space
+    var matchingCountLeft = 0
+    for (i in 0 until inventory.size()) {
+        val stack = inventory.getStack(i)
+        if (stack.isEmpty) {
+            matchingCountLeft += rollbackStack.maxCount
+        } else if (ItemStack.areItemsAndComponentsEqual(stack, rollbackStack)) {
+            matchingCountLeft += stack.maxCount - stack.count
+        }
+    }
+    if (matchingCountLeft < rollbackStack.count) {
+        return false
+    }
+    var requiredCount = rollbackStack.count
+    for (i in 0 until inventory.size()) {
+        val stack = inventory.getStack(i)
+        if (stack.isEmpty) {
+            if (requiredCount > rollbackStack.maxCount) {
+                inventory.setStack(i, rollbackStack.copyWithCount(rollbackStack.maxCount))
+                requiredCount -= rollbackStack.maxCount
+            } else {
+                inventory.setStack(i, rollbackStack.copyWithCount(requiredCount))
+                requiredCount = 0
+            }
+        } else if (ItemStack.areItemsAndComponentsEqual(stack, rollbackStack)) {
+            val countUntilMax = rollbackStack.maxCount - stack.count
+            if (requiredCount > countUntilMax) {
+                inventory.setStack(i, rollbackStack.copyWithCount(rollbackStack.maxCount))
+                requiredCount -= countUntilMax
+            } else {
+                inventory.setStack(i, rollbackStack.copyWithCount(stack.count + requiredCount))
+                requiredCount = 0
+            }
+        }
+        if (requiredCount <= 0) {
+            return true
+        }
+    }
+    return false
+}
+
+fun removeMatchingItem(rollbackStack: ItemStack, inventory: Inventory): Boolean {
+    // Check if the inventory has enough matching items
+    var matchingCount = 0
+    for (i in 0 until inventory.size()) {
+        val stack = inventory.getStack(i)
+        if (ItemStack.areItemsAndComponentsEqual(stack, rollbackStack)) {
+            matchingCount += stack.count
+        }
+    }
+    if (matchingCount < rollbackStack.count) {
+        return false
+    }
+    var requiredCount = rollbackStack.count
+    for (i in 0 until inventory.size()) {
+        val stack = inventory.getStack(i)
+        if (ItemStack.areItemsAndComponentsEqual(stack, rollbackStack)) {
+            if (requiredCount < stack.count) {
+                // Only some parts of this stack are needed
+                inventory.setStack(i, stack.copyWithCount(stack.count - requiredCount))
+                requiredCount = 0
+            } else {
+                inventory.setStack(i, ItemStack.EMPTY)
+                requiredCount -= stack.count
+            }
+            if (requiredCount <= 0) {
+                return true
+            }
+        }
+    }
+    return false
+}


### PR DESCRIPTION
- Significantly improved item changes
  - Item changes now properly check against components, not just item
  - Removing / adding to partial stacks is now possible
  - Previews now use the same logic as rollbacks to display changes
- Don't mark failed rollbacks as rolled back in the database