### PR TITLE
Fix search packet and entity change action extra data

### DIFF
--- a/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
@@ -248,7 +248,7 @@ object ActionFactory {
         action.oldObjectIdentifier = Registries.ENTITY_TYPE.getId(entity.type)
 
         if (itemStack != null) {
-            action.extraData = Registries.ITEM.getId(itemStack.item).toString()
+            action.extraData = itemStack.encode(world.registryManager)?.asString()
         }
         action.oldObjectState = oldEntityTags.asString()
         action.objectState = entity.writeNbt(NbtCompound())?.asString()

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/NbtUtils.kt
@@ -60,6 +60,6 @@ object NbtUtils {
             ).cast(NbtOps.INSTANCE) as NbtCompound?
         }
 
-        return ItemStack.fromNbt(registries, itemTag).get()
+        return ItemStack.fromNbt(registries, itemTag).orElse(ItemStack.EMPTY)
     }
 }

--- a/src/testmod/java/com/github/quiltservertools/ledger/testmod/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/testmod/java/com/github/quiltservertools/ledger/testmod/mixin/ClientPlayerInteractionManagerMixin.java
@@ -19,11 +19,11 @@ public class ClientPlayerInteractionManagerMixin {
         method = "interactBlock",
         at = @At(
             value = "INVOKE",
-            target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;)V"
+            target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;sendSequencedPacket(Lnet/minecraft/client/world/ClientWorld;Lnet/minecraft/client/network/SequencedPacketCreator;)V"
         ),
         cancellable = true
     )
-    private void onInteractBlock(ClientPlayerEntity player, ClientWorld world, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
+    private void onInteractBlock(ClientPlayerEntity player, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
         if (!InspectCommand.INSTANCE.getInspectOn())
             return;
 

--- a/src/testmod/kotlin/com/github/quiltservertools/ledger/testmod/LedgerTest.kt
+++ b/src/testmod/kotlin/com/github/quiltservertools/ledger/testmod/LedgerTest.kt
@@ -17,10 +17,10 @@ import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 
 object LedgerTest : ClientModInitializer {
-    val HANDSHAKE = Identifier("ledger", "handshake")
-    val INSPECT = Identifier("ledger", "inspect")
-    val SEARCH = Identifier("ledger", "search")
-    val ACTION = Identifier("ledger", "action")
+    val HANDSHAKE = Identifier.of("ledger", "handshake")
+    val INSPECT = Identifier.of("ledger", "inspect")
+    val SEARCH = Identifier.of("ledger", "search")
+    val ACTION = Identifier.of("ledger", "action")
     val LOGGER: Logger = LogManager.getLogger("LedgerTestmod")
 
     override fun onInitializeClient() {


### PR DESCRIPTION
Check discord for details.
TLDR: 
- Search packet was incorrectly updated during the 1.20.5 update.
- The entity change action extra data field only stores the item id of items that are used during item changing. This is inconsistent with other actions and causes hovering over the  action message to not show item details such as enchants. This has been fixed by storing all item data and if item data can't be parsed falling back to the old format (for de-serialization).