### PR TITLE
Database optimize

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -48,7 +48,7 @@ wdmcf = { module = "me.bymartrixx:wdmcf", version.ref = "wdmcf" }
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detect" }
-loom = { id = "fabric-loom", version = "1.6.+" }
+loom = { id = "fabric-loom", version = "1.7.3" }
 git_hooks = { id = "com.github.jakemarsden.git-hooks", version = "0.0.2" }
 # https://github.com/johnrengelman/shadow/issues/894
 shadow = { id = "io.github.goooler.shadow", version = "8.1.7" }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/Tables.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/Tables.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.javatime.timestamp
 import java.time.Instant
@@ -55,18 +56,18 @@ object Tables {
 
     object Actions : IntIdTable("actions") {
         val actionIdentifier = reference("action_id", ActionIdentifiers.id).index()
-        val timestamp = timestamp("time")
+        val timestamp = long("time")
         val x = integer("x")
         val y = integer("y")
         val z = integer("z")
         val world = reference("world_id", Worlds.id)
         val objectId = reference("object_id", ObjectIdentifiers.id).index()
         val oldObjectId = reference("old_object_id", ObjectIdentifiers.id).index()
-        val blockState = text("block_state").nullable()
-        val oldBlockState = text("old_block_state").nullable()
+        val blockState = optReference("block_state_ref", Strings.id)
+        val oldBlockState = optReference("old_block_state_ref", Strings.id)
         val sourceName = reference("source", Sources.id).index()
         val sourcePlayer = optReference("player_id", Players.id).index()
-        val extraData = text("extra_data").nullable()
+        val extraData = optReference("extra_data_ref", Strings.id)
         val rolledBack = bool("rolled_back").clientDefault { false }
 
         init {
@@ -111,5 +112,10 @@ object Tables {
         var identifier by Worlds.identifier.transform({ it.toString() }, { Identifier.tryParse(it)!! })
 
         companion object : IntEntityClass<World>(Worlds)
+    }
+
+    object Strings : LongIdTable("strings") {
+        val hash = integer("java_hash_code").index()
+        val value = text("value")
     }
 }


### PR DESCRIPTION
This PR optimize database size in various ways:
* Use long instead of string to store timestamp
* Use a separate string table to store strings, also use java hash code to optimize searching.

What to do:
* implement full support of old scheme.
* maybe in 1.4.x we can publish this feature, and no longer create new data in old scheme.
* totally drop the old scheme in the future.