### PR TITLE
Fix ClassCastException when performing preview including non-living entities.

### DIFF
--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/EntityKillActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/EntityKillActionType.kt
@@ -11,6 +11,7 @@ import net.minecraft.registry.Registries
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.network.EntityTrackerEntry
 import net.minecraft.server.network.ServerPlayerEntity
+import net.minecraft.server.world.ServerWorld
 import net.minecraft.util.math.Vec3d
 
 class EntityKillActionType : AbstractActionType() {
@@ -18,17 +19,23 @@ class EntityKillActionType : AbstractActionType() {
 
     override fun getTranslationType() = "entity"
 
-    override fun previewRollback(preview: Preview, player: ServerPlayerEntity) {
-        val world = player.server.getWorld(world)
-
+    private fun getEntity(world: ServerWorld): Entity? {
         val entityType = Registries.ENTITY_TYPE.getOptionalValue(objectIdentifier)
-        if (entityType.isEmpty) return
+        if (entityType.isEmpty) return null
 
-        val entity: LivingEntity = (entityType.get().create(world, SpawnReason.COMMAND) as LivingEntity?)!!
+        val entity = entityType.get().create(world, SpawnReason.COMMAND)!!
         entity.readNbt(StringNbtReader.parse(extraData))
-        entity.health = entity.defaultMaxHealth.toFloat()
         entity.velocity = Vec3d.ZERO
         entity.fireTicks = 0
+        if (entity is LivingEntity) entity.health = entity.defaultMaxHealth.toFloat()
+
+        return entity
+    }
+
+    override fun previewRollback(preview: Preview, player: ServerPlayerEntity) {
+        val world = player.server.getWorld(world)!!
+        val entity = getEntity(world)
+
         val entityTrackerEntry = EntityTrackerEntry(world, entity, 1, false) { }
         entityTrackerEntry.startTracking(player)
         preview.spawnedEntityTrackers.add(entityTrackerEntry)
@@ -50,22 +57,11 @@ class EntityKillActionType : AbstractActionType() {
     }
 
     override fun rollback(server: MinecraftServer): Boolean {
-        val world = server.getWorld(world)
+        val world = server.getWorld(world)!!
+        val entity = getEntity(world) ?: return false
 
-        val entityType = Registries.ENTITY_TYPE.getOptionalValue(objectIdentifier)
-        if (entityType.isPresent) {
-            val entity = entityType.get().create(world, SpawnReason.COMMAND)!!
-            entity.readNbt(StringNbtReader.parse(extraData))
-            entity.velocity = Vec3d.ZERO
-            entity.fireTicks = 0
-            if (entity is LivingEntity) entity.health = entity.defaultMaxHealth.toFloat()
-
-            world?.spawnEntity(entity)
-
-            return true
-        }
-
-        return false
+        world.spawnEntity(entity)
+        return true
     }
 
     override fun restore(server: MinecraftServer): Boolean {


### PR DESCRIPTION
Resolves errors like
```
[14:28:49 ERROR] [DefaultDispatcher-worker-9]: [FabricLoader] Uncaught exception in thread "DefaultDispatcher-worker-9"                                                                                                                                                                     
java.lang.ClassCastException: class net.minecraft.class_1533 cannot be cast to class net.minecraft.class_1309 (net.minecraft.class_1533 and net.minecraft.class_1309 are in unnamed module of loader 'knot' @4cc0edeb)
        at knot/com.github.quiltservertools.ledger.actions.EntityKillActionType.previewRollback(EntityKillActionType.kt:27) ~[ledger-1.3.7.jar:?]                                                                                                                                           
        at knot/com.github.quiltservertools.ledger.actionutils.Preview.<init>(Preview.kt:44) ~[ledger-1.3.7.jar:?]                            
        at knot/com.github.quiltservertools.ledger.commands.subcommands.PreviewCommand$preview$1.invokeSuspend(PreviewCommand.kt:67) ~[ledger-1.3.7.jar:?]                                                                                                                                  
        at knot/kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33) [org_jetbrains_kotlin_kotlin-stdlib-2.1.20-7cdd07a608b81ca8.jar:?]                                                                                                                   
        at knot/kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100) [org_jetbrains_kotlinx_kotlinx-co-jvm-1.10.1-e60f893de62e97b9.jar:?]
        at knot/kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586) [org_jetbrains_kotlinx_kotlinx-co-jvm-1.10.1-e60f893de62e97b9.jar:?]         
        at knot/kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829) [org_jetbrains_kotlinx_kotlinx-co-jvm-1.10.1-e60f893de62e97b9.jar:?]                                                                                                         
        at knot/kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717) [org_jetbrains_kotlinx_kotlinx-co-jvm-1.10.1-e60f893de62e97b9.jar:?]
        at knot/kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704) [org_jetbrains_kotlinx_kotlinx-co-jvm-1.10.1-e60f893de62e97b9.jar:?]                                                                                                                 
        Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException
```
when attempting to preview a rollback that includes entities that do not extend LivingEntity, resulting in a confusing `No current preview` error in chat when a user attempts to apply the preview.