### PR TITLE
Update to 1.21.6

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-minecraft = "1.21.5"
-yarn-mappings = "1.21.5+build.1"
-fabric-loader = "0.16.10"
+minecraft = "1.21.6-rc1"
+yarn-mappings = "1.21.6-rc1+build.1"
+fabric-loader = "0.16.14"
 
-fabric-api = "0.119.5+1.21.5"
+fabric-api = "0.126.1+1.21.6"
 
 # Kotlin
 kotlin = "2.1.0"
 # Also modrinth version in gradle.properties
 fabric-kotlin = "1.13.0+kotlin.2.1.0"
 
-fabric-permissions = "0.3.3"
-translations = "2.5.0+1.21.5-rc1"
+fabric-permissions = "0.4.0-SNAPSHOT"
+translations = "2.5.1+1.21.5"
 
 exposed = "0.58.0"
 sqlite-jdbc = "3.47.2.0"

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/DyeItemMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/DyeItemMixin.java
@@ -1,6 +1,7 @@
 package com.github.quiltservertools.ledger.mixin;
 
 import com.github.quiltservertools.ledger.callbacks.EntityModifyCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.github.quiltservertools.ledger.utility.Sources;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -22,7 +23,7 @@ public abstract class DyeItemMixin {
 
     @Inject(method = "useOnEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SheepEntity;setColor(Lnet/minecraft/util/DyeColor;)V"))
     private void ledgerOldEntity(ItemStack stack, PlayerEntity player, LivingEntity entity, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
-        oldEntityTags = entity.writeNbt(new NbtCompound());
+        oldEntityTags = NbtUtils.INSTANCE.createNbt(entity);
     }
 
     @Inject(method = "useOnEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SheepEntity;setColor(Lnet/minecraft/util/DyeColor;)V", shift = At.Shift.AFTER))

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/cauldron/LeveledCauldronBlockMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/cauldron/LeveledCauldronBlockMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityCollisionHandler;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluid;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -51,11 +52,11 @@ public abstract class LeveledCauldronBlockMixin {
         }
     }
 
-    @Inject(method = "onEntityCollision", at = @At(value = "INVOKE",
+    @Inject(method = "method_71627", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/block/LeveledCauldronBlock;onFireCollision(Lnet/minecraft/block/BlockState;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;)V"))
-    private void ledgerLogPlayerExtinguish(BlockState state, World world, BlockPos pos, Entity entity, EntityCollisionHandler handler, CallbackInfo ci) {
-        if (entity instanceof PlayerEntity) {
-            playerEntity = (PlayerEntity) entity;
+    private void ledgerLogPlayerExtinguish(ServerWorld serverWorld, BlockPos blockPos, BlockState blockState, World world, Entity collidedEntity, CallbackInfo ci) {
+        if (collidedEntity instanceof PlayerEntity) {
+            playerEntity = (PlayerEntity) collidedEntity;
         }
     }
 

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/lectern/LecternScreenHandlerMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/lectern/LecternScreenHandlerMixin.java
@@ -20,6 +20,6 @@ public class LecternScreenHandlerMixin {
     public void logPickBook(PlayerEntity player, int id, CallbackInfoReturnable<Boolean> cir, @Local ItemStack itemStack) {
         ServerPlayerEntity serverPlayer = (ServerPlayerEntity) player;
         BlockEntity blockEntity = PlayerLecternHook.getActiveHandlers().get(player);
-        ItemRemoveCallback.EVENT.invoker().remove(itemStack, blockEntity.getPos(), serverPlayer.getServerWorld(), Sources.PLAYER, serverPlayer);
+        ItemRemoveCallback.EVENT.invoker().remove(itemStack, blockEntity.getPos(), serverPlayer.getWorld(), Sources.PLAYER, serverPlayer);
     }
 }

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/AbstractSignBlockMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/AbstractSignBlockMixin.java
@@ -1,6 +1,7 @@
 package com.github.quiltservertools.ledger.mixin.blocks.sign;
 
 import com.github.quiltservertools.ledger.callbacks.BlockChangeCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.block.AbstractSignBlock;
@@ -57,7 +58,7 @@ public class AbstractSignBlockMixin {
         DynamicRegistryManager registryManager = world.getRegistryManager();
 
         // a bad hack to copy the old sign block entity for rollbacks
-        @Nullable BlockEntity oldSignEntity = BlockEntity.createFromNbt(pos, state, signBlockEntity.createNbtWithId(registryManager), registryManager);
+        @Nullable BlockEntity oldSignEntity = BlockEntity.createFromNbt(pos, state, NbtUtils.INSTANCE.createNbt(signBlockEntity, registryManager), registryManager);
 
         boolean result = original.call(instance, world, signBlockEntity, front, player);
         if (result && oldSignEntity != null) {

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/SignBlockEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/sign/SignBlockEntityMixin.java
@@ -1,6 +1,7 @@
 package com.github.quiltservertools.ledger.mixin.blocks.sign;
 
 import com.github.quiltservertools.ledger.callbacks.BlockChangeCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.block.BlockState;
@@ -54,7 +55,7 @@ public abstract class SignBlockEntityMixin {
         BlockState state = instance.getCachedState();
 
         // a bad hack to copy the old sign block entity for rollbacks
-        @Nullable BlockEntity oldSignEntity = BlockEntity.createFromNbt(pos, state, instance.createNbtWithId(registryManager), registryManager);
+        @Nullable BlockEntity oldSignEntity = BlockEntity.createFromNbt(pos, state, NbtUtils.INSTANCE.createNbt(instance, registryManager), registryManager);
 
         boolean result = original.call(instance, textChanger, front);
         if (result && oldSignEntity != null) {

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/entities/ArmorStandEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/entities/ArmorStandEntityMixin.java
@@ -2,6 +2,7 @@ package com.github.quiltservertools.ledger.mixin.entities;
 
 import com.github.quiltservertools.ledger.callbacks.EntityKillCallback;
 import com.github.quiltservertools.ledger.callbacks.EntityModifyCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.github.quiltservertools.ledger.utility.Sources;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
@@ -29,7 +30,7 @@ public abstract class ArmorStandEntityMixin {
     @Inject(method = "equip", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/decoration/ArmorStandEntity;equipStack(Lnet/minecraft/entity/EquipmentSlot;Lnet/minecraft/item/ItemStack;)V"))
     private void legerLogOldEntity(PlayerEntity player, EquipmentSlot slot, ItemStack playerStack, Hand hand, CallbackInfoReturnable<Boolean> cir) {
         LivingEntity entity = (LivingEntity) (Object) this;
-        this.oldEntityTags = entity.writeNbt(new NbtCompound());
+        this.oldEntityTags = NbtUtils.INSTANCE.createNbt(entity);
         this.oldEntityStack = entity.getEquippedStack(slot);
     }
 

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/entities/CatEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/entities/CatEntityMixin.java
@@ -1,6 +1,7 @@
 package com.github.quiltservertools.ledger.mixin.entities;
 
 import com.github.quiltservertools.ledger.callbacks.EntityModifyCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.github.quiltservertools.ledger.utility.Sources;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.passive.CatEntity;
@@ -22,7 +23,7 @@ public abstract class CatEntityMixin {
     @Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/CatEntity;setCollarColor(Lnet/minecraft/util/DyeColor;)V"))
     private void ledgerLogOldEntity(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         LivingEntity entity = (LivingEntity) (Object) this;
-        this.oldEntityTags = entity.writeNbt(new NbtCompound());
+        this.oldEntityTags = NbtUtils.INSTANCE.createNbt(entity);
     }
 
     @Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/CatEntity;setCollarColor(Lnet/minecraft/util/DyeColor;)V", shift = At.Shift.AFTER))

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/entities/EvokerEntityWololoGoalMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/entities/EvokerEntityWololoGoalMixin.java
@@ -1,7 +1,9 @@
 package com.github.quiltservertools.ledger.mixin.entities;
 
 import com.github.quiltservertools.ledger.callbacks.EntityModifyCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.github.quiltservertools.ledger.utility.Sources;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.entity.mob.EvokerEntity;
 import net.minecraft.entity.passive.SheepEntity;
 import net.minecraft.item.Items;
@@ -19,15 +21,15 @@ public abstract class EvokerEntityWololoGoalMixin {
     @Unique
     private NbtCompound oldEntityTags;
 
-    @Inject(method = "castSpell", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SheepEntity;setColor(Lnet/minecraft/util/DyeColor;)V"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
-    public void legerLogOldEntity(CallbackInfo ci, SheepEntity sheepEntity) {
+    @Inject(method = "castSpell", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SheepEntity;setColor(Lnet/minecraft/util/DyeColor;)V"))
+    public void legerLogOldEntity(CallbackInfo ci, @Local SheepEntity sheepEntity) {
         if (sheepEntity.getColor() != DyeColor.RED) {
-            this.oldEntityTags = sheepEntity.writeNbt(new NbtCompound());
+            this.oldEntityTags = NbtUtils.INSTANCE.createNbt(sheepEntity);
         }
     }
 
-    @Inject(method = "castSpell", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SheepEntity;setColor(Lnet/minecraft/util/DyeColor;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
-    public void ledgerEvokerDyeSheep(CallbackInfo ci, SheepEntity sheepEntity) {
+    @Inject(method = "castSpell", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SheepEntity;setColor(Lnet/minecraft/util/DyeColor;)V", shift = At.Shift.AFTER))
+    public void ledgerEvokerDyeSheep(CallbackInfo ci, @Local SheepEntity sheepEntity) {
         if (oldEntityTags != null) {
             EntityModifyCallback.EVENT.invoker().modify(sheepEntity.getWorld(), sheepEntity.getBlockPos(), oldEntityTags, sheepEntity, Items.RED_DYE.getDefaultStack(), null, Sources.DYE);
         }

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/entities/ItemFrameEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/entities/ItemFrameEntityMixin.java
@@ -2,6 +2,7 @@ package com.github.quiltservertools.ledger.mixin.entities;
 
 import com.github.quiltservertools.ledger.callbacks.EntityKillCallback;
 import com.github.quiltservertools.ledger.callbacks.EntityModifyCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.github.quiltservertools.ledger.utility.Sources;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.damage.DamageSource;
@@ -31,7 +32,7 @@ public abstract class ItemFrameEntityMixin {
     @Inject(method = "interact", at = @At(value = "HEAD"))
     private void ledgerLogOldEntity(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         Entity entity = (Entity) (Object) this;
-        oldEntityTags = entity.writeNbt(new NbtCompound());
+        oldEntityTags = NbtUtils.INSTANCE.createNbt(entity);
     }
 
     @Inject(method = "dropHeldStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/decoration/ItemFrameEntity;setHeldItemStack(Lnet/minecraft/item/ItemStack;)V"))
@@ -40,7 +41,7 @@ public abstract class ItemFrameEntityMixin {
             return;
         }
         Entity entity = (Entity) (Object) this;
-        oldEntityTags = entity.writeNbt(new NbtCompound());
+        oldEntityTags = NbtUtils.INSTANCE.createNbt(entity);
     }
 
     @Inject(method = "interact", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/decoration/ItemFrameEntity;setHeldItemStack(Lnet/minecraft/item/ItemStack;)V", shift = At.Shift.AFTER))

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/entities/LightningEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/entities/LightningEntityMixin.java
@@ -24,7 +24,7 @@ public abstract class LightningEntityMixin {
     )
     private void logFirePlacedByLightningBolt(int spreadAttempts, CallbackInfo ci, @Local BlockPos blockPos, @Local BlockState blockState) {
         LightningEntity entity = (LightningEntity) (Object) this;
-        BlockPlaceCallback.EVENT.invoker().place(entity.getEntityWorld(), blockPos, blockState, null, Registries.ENTITY_TYPE.getId(entity.getType()).getPath());
+        BlockPlaceCallback.EVENT.invoker().place(entity.getWorld(), blockPos, blockState, null, Registries.ENTITY_TYPE.getId(entity.getType()).getPath());
     }
 
     @Inject(
@@ -38,6 +38,6 @@ public abstract class LightningEntityMixin {
     )
     private void logFirePlacedByLightningBoltSpread(int spreadAttempts, CallbackInfo ci, @Local(ordinal = 1) BlockPos blockPos, @Local BlockState blockState) {
         LightningEntity entity = (LightningEntity) (Object) this;
-        BlockPlaceCallback.EVENT.invoker().place(entity.getEntityWorld(), blockPos, blockState, null, Registries.ENTITY_TYPE.getId(entity.getType()).getPath());
+        BlockPlaceCallback.EVENT.invoker().place(entity.getWorld(), blockPos, blockState, null, Registries.ENTITY_TYPE.getId(entity.getType()).getPath());
     }
 }

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/entities/SheepEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/entities/SheepEntityMixin.java
@@ -1,6 +1,7 @@
 package com.github.quiltservertools.ledger.mixin.entities;
 
 import com.github.quiltservertools.ledger.callbacks.EntityModifyCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.github.quiltservertools.ledger.utility.Sources;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.passive.SheepEntity;
@@ -22,7 +23,7 @@ public abstract class SheepEntityMixin {
     @Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SheepEntity;sheared(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/sound/SoundCategory;Lnet/minecraft/item/ItemStack;)V"))
     private void ledgerLogOldEntity(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         LivingEntity entity = (LivingEntity) (Object) this;
-        oldEntityTags = entity.writeNbt(new NbtCompound());
+        oldEntityTags = NbtUtils.INSTANCE.createNbt(entity);
     }
 
     @Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SheepEntity;sheared(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/sound/SoundCategory;Lnet/minecraft/item/ItemStack;)V", shift = At.Shift.AFTER))

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/entities/SnowGolemEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/entities/SnowGolemEntityMixin.java
@@ -2,6 +2,7 @@ package com.github.quiltservertools.ledger.mixin.entities;
 
 import com.github.quiltservertools.ledger.callbacks.BlockPlaceCallback;
 import com.github.quiltservertools.ledger.callbacks.EntityModifyCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.github.quiltservertools.ledger.utility.Sources;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.block.BlockState;
@@ -32,7 +33,7 @@ public abstract class SnowGolemEntityMixin {
     @Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SnowGolemEntity;sheared(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/sound/SoundCategory;Lnet/minecraft/item/ItemStack;)V"))
     private void ledgerOldEntity(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         LivingEntity entity = (LivingEntity) (Object) this;
-        oldEntityTags = entity.writeNbt(new NbtCompound());
+        oldEntityTags = NbtUtils.INSTANCE.createNbt(entity);
     }
 
     @Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/SnowGolemEntity;sheared(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/sound/SoundCategory;Lnet/minecraft/item/ItemStack;)V", shift = At.Shift.AFTER))

--- a/src/main/java/com/github/quiltservertools/ledger/mixin/entities/WolfEntityMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/entities/WolfEntityMixin.java
@@ -1,6 +1,7 @@
 package com.github.quiltservertools.ledger.mixin.entities;
 
 import com.github.quiltservertools.ledger.callbacks.EntityModifyCallback;
+import com.github.quiltservertools.ledger.utility.NbtUtils;
 import com.github.quiltservertools.ledger.utility.Sources;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.passive.WolfEntity;
@@ -22,7 +23,7 @@ public abstract class WolfEntityMixin {
     @Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/WolfEntity;setCollarColor(Lnet/minecraft/util/DyeColor;)V"))
     private void ledgerOldEntity(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         LivingEntity entity = (LivingEntity) (Object) this;
-        oldEntityTags = entity.writeNbt(new NbtCompound());
+        oldEntityTags = NbtUtils.INSTANCE.createNbt(entity);
     }
 
     @Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/WolfEntity;setCollarColor(Lnet/minecraft/util/DyeColor;)V", shift = At.Shift.AFTER))

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/BlockPlaceActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/BlockPlaceActionType.kt
@@ -1,5 +1,6 @@
 package com.github.quiltservertools.ledger.actions
 
+import com.github.quiltservertools.ledger.utility.LOGGER
 import com.github.quiltservertools.ledger.utility.TextColorPallet
 import com.github.quiltservertools.ledger.utility.getWorld
 import com.github.quiltservertools.ledger.utility.literal
@@ -7,8 +8,10 @@ import net.minecraft.nbt.StringNbtReader
 import net.minecraft.registry.RegistryKeys
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.command.ServerCommandSource
+import net.minecraft.storage.NbtReadView
 import net.minecraft.text.HoverEvent
 import net.minecraft.text.Text
+import net.minecraft.util.ErrorReporter
 import net.minecraft.util.Util
 
 class BlockPlaceActionType : BlockChangeActionType() {
@@ -28,7 +31,15 @@ class BlockPlaceActionType : BlockChangeActionType() {
             val state = newBlockState(world.createCommandRegistryWrapper(RegistryKeys.BLOCK))
             world.setBlockState(pos, state)
             if (state.hasBlockEntity()) {
-                world.getBlockEntity(pos)?.read(StringNbtReader.readCompound(extraData), server.registryManager)
+                ErrorReporter.Logging({ "ledger:restore:block-place@$pos" }, LOGGER).use {
+                    world.getBlockEntity(pos)?.read(
+                        NbtReadView.create(
+                            it,
+                            server.registryManager,
+                            StringNbtReader.readCompound(extraData)
+                        )
+                    )
+                }
             }
         }
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemChangeActionType.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actions/ItemChangeActionType.kt
@@ -50,7 +50,7 @@ abstract class ItemChangeActionType : AbstractActionType() {
     }
 
     protected fun previewItemChange(preview: Preview, player: ServerPlayerEntity, insert: Boolean) {
-        val world = player.server.getWorld(world)
+        val world = player.world.server.getWorld(world)
         val state = world?.getBlockState(pos)
         state?.isOf(Blocks.CHEST)?.let {
             if (it) {
@@ -66,7 +66,7 @@ abstract class ItemChangeActionType : AbstractActionType() {
     private fun addPreview(preview: Preview, player: ServerPlayerEntity, pos: BlockPos, insert: Boolean) {
         preview.modifiedItems.compute(pos) { _, list ->
             list ?: mutableListOf()
-        }?.add(Pair(getStack(player.server), insert))
+        }?.add(Pair(getStack(player.world.server), insert))
     }
 
     private fun getInventory(world: ServerWorld): Inventory? {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/actionutils/ActionFactory.kt
@@ -11,6 +11,7 @@ import com.github.quiltservertools.ledger.actions.ItemInsertActionType
 import com.github.quiltservertools.ledger.actions.ItemPickUpActionType
 import com.github.quiltservertools.ledger.actions.ItemRemoveActionType
 import com.github.quiltservertools.ledger.utility.NbtUtils
+import com.github.quiltservertools.ledger.utility.NbtUtils.createNbt
 import com.github.quiltservertools.ledger.utility.Sources
 import net.minecraft.block.BlockState
 import net.minecraft.block.Blocks
@@ -147,7 +148,7 @@ object ActionFactory {
 
         setItemData(action, entity.blockPos, entity.world, entity.stack, Sources.PLAYER)
 
-        action.oldObjectState = entity.writeNbt(NbtCompound())?.toString()
+        action.oldObjectState = entity.createNbt().toString()
         action.sourceProfile = source.gameProfile
 
         return action
@@ -161,7 +162,7 @@ object ActionFactory {
 
         setItemData(action, entity.blockPos, entity.world, entity.stack, Sources.PLAYER)
 
-        action.objectState = entity.writeNbt(NbtCompound())?.toString()
+        action.objectState = entity.createNbt().toString()
         action.sourceProfile = source.gameProfile
 
         return action
@@ -194,7 +195,7 @@ object ActionFactory {
         action.objectIdentifier = Registries.ITEM.getId(stack.item)
         action.sourceName = source
         if (!stack.isEmpty) {
-            action.extraData = stack.toNbt(world.registryManager)?.toString()
+            action.extraData = stack.createNbt(world.registryManager).toString()
         }
     }
 
@@ -236,7 +237,7 @@ object ActionFactory {
         action.world = world.registryKey.value
         action.objectIdentifier = Registries.ENTITY_TYPE.getId(entity.type)
         action.sourceName = source
-        action.extraData = entity.writeNbt(NbtCompound())?.toString()
+        action.extraData = entity.createNbt().toString()
     }
 
     fun entityChangeAction(
@@ -256,10 +257,10 @@ object ActionFactory {
         action.oldObjectIdentifier = Registries.ENTITY_TYPE.getId(entity.type)
 
         if (itemStack != null && !itemStack.isEmpty) {
-            action.extraData = itemStack.toNbt(world.registryManager)?.toString()
+            action.extraData = itemStack.createNbt(world.registryManager).toString()
         }
         action.oldObjectState = oldEntityTags.toString()
-        action.objectState = entity.writeNbt(NbtCompound())?.toString()
+        action.objectState = entity.createNbt().toString()
         action.sourceName = sourceType
 
         if (entityActor is PlayerEntity) {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/InspectionManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/InspectionManager.kt
@@ -135,7 +135,7 @@ private fun getOtherBedPart(state: BlockState, pos: BlockPos): BlockPos {
 }
 
 suspend fun ServerPlayerEntity.getInspectResults(pos: BlockPos): SearchResults {
-    val source = this.getCommandSource(this.serverWorld)
+    val source = this.commandSource
     val params = ActionSearchParams.build {
         bounds = BlockBox(pos)
     }


### PR DESCRIPTION
Primarily nbt read / write changes. 

To read / write nbt data a `ReadView` / `WriteView` needs to be passed, which contains a context, which can be used for tracking errors.

All read views in rollbacks / restores have a custom context. Read views in previews have any empty context (and no logging). All write views for logging use their vanilla context.