### PR TITLE
Teleport to block center instead of corner

### DIFF
--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/TeleportCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/TeleportCommand.kt
@@ -33,11 +33,15 @@ object TeleportCommand : BuildableCommand {
     private fun teleport(context: Context, world: ServerWorld, posArg: PosArgument): Int {
         val player = context.source.playerOrThrow
         val pos = posArg.toAbsoluteBlockPos(context.source)
+
+        val x = pos.x.toDouble() + 0.5
+        val z = pos.z.toDouble() + 0.5
+
         player.teleport(
             world,
-            pos.x.toDouble(),
+            x,
             pos.y.toDouble(),
-            pos.z.toDouble(),
+            z,
             emptySet(),
             player.yaw,
             player.pitch,


### PR DESCRIPTION
Adjusts the teleport command to move players to the center of the target block (x + 0.5, z + 0.5) instead of the block corner.