### PR TITLE
fix: range NPE

### DIFF
--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
@@ -88,7 +88,7 @@ object SearchParamArgument {
     @Suppress("UNCHECKED_CAST")
     fun get(input: String, source: CommandSourceStack): ActionSearchParams {
         val reader = StringReader(input)
-        val result = HashMultimap.create<String, Any>()
+        val result = HashMultimap.create<String, Any?>()
         while (reader.canRead()) {
             val propertyName = reader.readStringUntil(':').trim(' ')
             val parameter = paramSuggesters[propertyName]
@@ -96,7 +96,7 @@ object SearchParamArgument {
                     .create()
             val value =
                 if (parameter is NegatableParameter) parameter.parseNegatable(reader) else parameter.parse(reader)
-            result.put(propertyName, value!!)
+            result.put(propertyName, value)
         }
 
         val builder = ActionSearchParams.Builder()


### PR DESCRIPTION
the hashmultimap has been of Any type since 2021, so honestly unsure why this change seems required now
did not test properly for side effects, but range:@global works with this at least