### PR TITLE
feat: add item tracking for Chiseled Bookshelf

### DIFF
--- a/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/ChiseledBookShelfBlockMixin.java
+++ b/src/main/java/com/github/quiltservertools/ledger/mixin/blocks/ChiseledBookShelfBlockMixin.java
@@ -1,0 +1,73 @@
+package com.github.quiltservertools.ledger.mixin.blocks;
+
+import com.github.quiltservertools.ledger.callbacks.ItemInsertCallback;
+import com.github.quiltservertools.ledger.callbacks.ItemRemoveCallback;
+import com.github.quiltservertools.ledger.utility.Sources;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.ChiseledBookShelfBlock;
+import net.minecraft.world.level.block.entity.ChiseledBookShelfBlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ChiseledBookShelfBlock.class)
+public class ChiseledBookShelfBlockMixin {
+
+    /**
+     * Fires ItemInsertCallback after a book is successfully placed into a chiseled bookshelf slot.
+     * Hooks into addBook(), which only runs server-side, after setItem() stores the book.
+     */
+    @Inject(
+        method = "addBook",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity;setItem(ILnet/minecraft/world/item/ItemStack;)V",
+            shift = At.Shift.AFTER
+        )
+    )
+    private static void onAddBook(
+        Level level,
+        BlockPos pos,
+        Player player,
+        ChiseledBookShelfBlockEntity bookshelfBlock,
+        ItemStack itemStack,
+        int slot,
+        CallbackInfo ci
+    ) {
+        ItemStack insertedBook = bookshelfBlock.getItem(slot);
+        if (!insertedBook.isEmpty() && level instanceof ServerLevel serverLevel) {
+            ItemInsertCallback.EVENT.invoker().insert(insertedBook, pos, serverLevel, Sources.PLAYER, player);
+        }
+    }
+
+    /**
+     * Fires ItemRemoveCallback when a book is removed from a chiseled bookshelf slot.
+     * Hooks into removeBook() to capture the removed ItemStack returned by removeItem().
+     */
+    @ModifyExpressionValue(
+        method = "removeBook",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity;removeItem(II)Lnet/minecraft/world/item/ItemStack;"
+        )
+    )
+    private static ItemStack onRemoveBook(
+        ItemStack removedStack,
+        Level level,
+        BlockPos pos,
+        Player player,
+        ChiseledBookShelfBlockEntity bookshelfBlock,
+        int slot
+    ) {
+        if (!removedStack.isEmpty() && level instanceof ServerLevel serverLevel) {
+            ItemRemoveCallback.EVENT.invoker().remove(removedStack, pos, serverLevel, Sources.PLAYER, player);
+        }
+        return removedStack;
+    }
+}

--- a/src/main/resources/ledger.mixins.json
+++ b/src/main/resources/ledger.mixins.json
@@ -40,6 +40,7 @@
         "blocks.CampfireBlockMixin",
         "blocks.CandleBlockMixin",
         "blocks.CarvedPumpkinBlockMixin",
+        "blocks.ChiseledBookShelfBlockMixin",
         "blocks.ChorusFlowerBlockMixin",
         "blocks.ChorusPlantBlockMixin",
         "blocks.ComparatorBlockMixin",


### PR DESCRIPTION
## What does this change?

Adds `item-insert` and `item-remove` action logging for the Chiseled Bookshelf block. When a player places a book into or removes a book from a Chiseled Bookshelf, the action is now logged and fully supports rollback and restore.

## Why?

The Chiseled Bookshelf bypasses the standard container menu system — players interact directly with the block face to slot and unslot books, so the existing `AbstractContainerMenuMixin` never fires for it. This left a gap in logging for a commonly used storage block.

## How?

Added `ChiseledBookShelfBlockMixin.java`, modelled directly on the existing `ShelfBlockMixin.java` pattern:

- `@Inject` into the private static `addBook()` method, firing `ItemInsertCallback` after `setItem()` stores the book
- `@ModifyExpressionValue` on `removeBook()`, capturing the `ItemStack` returned by `removeItem()` and firing `ItemRemoveCallback`

Both hooks only run server-side (guard on `level instanceof ServerLevel`), matching the pattern used throughout the codebase.

`ChiseledBookShelfBlockEntity` implements `ListBackedContainer extends Container`, so rollback and restore work through the existing `ItemChangeActionType.getInventory()` path with no changes needed.

## Testing

Tested on a local Fabric 0.18.4 / Minecraft 1.26.1 server:
- Inserted a regular book and an enchanted book into a Chiseled Bookshelf — both logged as `item-insert`
- Removed both books — both logged as `item-remove`
- `/ledger rollback range:2 action:item-insert after:10m` — books correctly removed from the bookshelf (2 rollback entries logged)
- Confirmed same actions logged correctly on a Chest for comparison

**Known limitation:** `/ledger preview rollback` does not visually reflect Chiseled Bookshelf changes. This is a pre-existing limitation of the preview system — `ServerPlayerEntityMixin` intercepts `ClientboundContainerSetContentPacket`, which is not sent for blocks that track slot state via block-state properties rather than a container screen. The same limitation exists for `ShelfBlock`. Actual rollback and restore work correctly.