### PR TITLE
fix: skip action rows with extra_data exceeding MySQL TEXT column limit

### DIFF
--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
@@ -73,6 +73,7 @@ import kotlin.math.ceil
 const val MAX_QUERY_RETRIES = 10
 const val MIN_RETRY_DELAY = 1000L
 const val MAX_RETRY_DELAY = 300_000L
+private const val MAX_EXTRA_DATA_BYTES = 65_535
 
 object DatabaseManager {
 
@@ -456,7 +457,18 @@ object DatabaseManager {
     }
 
     private fun Transaction.insertActions(actions: List<ActionType>) {
-        Tables.Actions.batchInsert(actions, shouldReturnGeneratedValues = false) { action ->
+        val (safe, oversized) = actions.partition {
+            it.extraData == null || it.extraData!!.length <= MAX_EXTRA_DATA_BYTES
+        }
+        oversized.forEach { action ->
+            logWarn(
+                "Skipping action log: extra_data too large (${action.extraData!!.length} chars) " +
+                    "for action ${action.identifier} at " +
+                    "[${action.world} ${action.pos.x} ${action.pos.y} ${action.pos.z}] " +
+                    "by ${action.sourceProfile?.name ?: action.sourceName}",
+            )
+        }
+        Tables.Actions.batchInsert(safe, shouldReturnGeneratedValues = false) { action ->
             this[Tables.Actions.actionIdentifier] = getOrCreateActionId(action.identifier)
             this[Tables.Actions.timestamp] = action.timestamp
             this[Tables.Actions.x] = action.pos.x


### PR DESCRIPTION
## What does this change?

Prevents a permanent retry loop when logging actions whose serialized NBT exceeds the MySQL `TEXT` column limit (65,535 bytes) for `extra_data`.

When a batch insert fails due to an oversized row, the offending action is now skipped with a `WARN` log entry. The remaining rows in the batch are inserted normally.

## Why?

The `extra_data` column is defined as `TEXT` in MySQL, which has a hard 65,535-byte limit. When a player picks up or interacts with a deeply nested item — such as a shulker box containing beehives with full bee entity NBT — the serialized NBT string can exceed this limit.

Before this fix, the `batchInsert` call in `insertActions()` would throw a `BatchUpdateException: Data too long for column 'extra_data'`, and the `execute()` retry wrapper would retry the same unresolvable batch up to `MAX_QUERY_RETRIES` (10) times before giving up, halting all logging on the server.

This was reproduced live: a fully-packed shulker box of beehives produces ~42KB of `extra_data` in vanilla, growing beyond 65,535 bytes when bees carry heavier entity NBT (custom names, active potion effects, hives with long lore). The overflow and retry loop were confirmed on a live server.

## How?

In `insertActions()` in `DatabaseManager.kt`, the incoming action list is partitioned before `batchInsert`:

- Any action whose `extraData` string length exceeds `MAX_EXTRA_DATA_BYTES` (65,535) is dropped
- A `WARN` is emitted for each dropped row with the action type, coordinates, world, and player name so operators can identify the trigger
- The remaining safe rows proceed to `batchInsert` as normal

Truncating was ruled out as it would produce invalid NBT, breaking rollback and restore. Catching `BatchUpdateException` after the fact was ruled out because Exposed does not identify which row caused the failure and the transaction is already in a failed state.

## Testing

**Steps to reproduce the bug (unpatched):**

1. Create a shulker box containing 27 beehives (all slots filled)
2. Each beehive must hold 3 bees (max occupancy) where every bee has:
   - A custom `CustomName` tag (named with an anvil)
   - At least one active potion effect
3. Each beehive item must have long lore text / attribute modifiers on it
4. Have a player pick up or break the shulker box
5. Observe `BatchUpdateException: Data too long for column 'extra_data'` in the log followed by repeated `Transaction attempt #N failed` retries — logging halts entirely

**Verified on patched build (live Fabric / Minecraft 1.26.1 server):**

- With the above setup, `extra_data` reached **76,996 chars** (117% of the 65,535-byte `TEXT` limit)
- Patched jar skipped the offending row with:
  `WARN: Skipping action log: extra_data too large (76996 chars) for action block-break at [minecraft:overworld ...] by Netcrafts`
- All other actions in the same batch were inserted correctly
- The logging queue resumed immediately with no further retries
- Standard beehive and shulker box interactions well under the limit log normally with no behaviour change