### PR TITLE
Add config option for running database schema updates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2G
 
 # Mod Properties
-modVersion = 1.3.21
+modVersion = 1.3.22
 mavenGroup = com.github.quiltservertools
 modId = ledger
 modName = Ledger

--- a/src/main/kotlin/com/github/quiltservertools/ledger/config/DatabaseSpec.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/config/DatabaseSpec.kt
@@ -15,6 +15,7 @@ object DatabaseSpec : ConfigSpec() {
     val batchDelay by optional<Int>(10)
     val logSQL by optional<Boolean>(false)
     val location by optional<String?>(null)
+    val updateSchema by optional<Boolean>(false)
 }
 
 fun Config.getDatabasePath(): Path {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/database/DatabaseManager.kt
@@ -122,10 +122,12 @@ object DatabaseManager {
             Tables.Sources,
             Tables.Worlds,
         )
-        try {
-            exec("CREATE INDEX IF NOT EXISTS actions_time ON actions(time)")
-        } catch (e: java.sql.SQLException) {
-            logWarn("Could not create actions_time index (MySQL 8.0.12+ required if using MySQL): ${e.message}")
+        if (config[DatabaseSpec.updateSchema]) {
+            try {
+                exec("CREATE INDEX IF NOT EXISTS actions_time ON actions(time)")
+            } catch (e: java.sql.SQLException) {
+                logWarn("Could not create actions_time index (MySQL 8.0.12+ required if using MySQL): ${e.message}")
+            }
         }
         logInfo("Tables created")
     }

--- a/src/main/resources/ledger.toml
+++ b/src/main/resources/ledger.toml
@@ -11,6 +11,8 @@ batchSize = 1000
 batchDelay = 10
 # The location of the database file. Defaults to the world folder if not specified
 #location = "./custom-dir"
+# Allow the database format to be updated on startup (can be slow)
+updateSchema = false
 
 [search]
 # Number of actions to show per page


### PR DESCRIPTION
Don't run schema migrations by default. Dont want to block startup for large databases