### PR TITLE
Migrate to Fabric Permissions API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,9 +64,6 @@ dependencies {
     // Fabric API
     implementation(libs.fabric.api)
 
-    // Permissions
-    implementationAndInclude(libs.fabric.permissions)
-
     // Translations
     implementationAndInclude(libs.translations)
 

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -1,7 +1,7 @@
 # Inspect
 `/ledger inspect`  
 Alias: `i`  
-Permission: `ledger.commands.inspect`
+Permission: `ledger:command/inspect` or permission level 3
 
 ---
 

--- a/docs/commands/player.md
+++ b/docs/commands/player.md
@@ -1,7 +1,7 @@
 # Player
 `/ledger player`  
-Permission: `ledger.commands.player`  
-Alias: `pl`
+Alias: `pl`  
+Permission: `ledger:command/player` or permission level 3
 
 ---
 

--- a/docs/commands/preview.md
+++ b/docs/commands/preview.md
@@ -1,7 +1,7 @@
 # Preview
 `/ledger preview`  
 Alias: `pv`  
-Permission: `ledger.commands.preview`
+Permission: `ledger:command/preview` or permission level 3
 
 ---
 

--- a/docs/commands/purge.md
+++ b/docs/commands/purge.md
@@ -1,6 +1,7 @@
 # Purge
-`/ledger purge`
-Permission: `ledger.commands.purge`
+`/ledger purge`  
+Alias: None  
+Permission: `ledger:command/purge` or purge permission level as specified in the config
 
 ---
 

--- a/docs/commands/restore.md
+++ b/docs/commands/restore.md
@@ -1,7 +1,7 @@
 # Restore
 `/ledger restore`  
 Alias: None  
-Permission: `ledger.commands.rollback`
+Permission: `ledger:command/rollback` or permission level 3
 
 ---
 

--- a/docs/commands/rollback.md
+++ b/docs/commands/rollback.md
@@ -1,7 +1,7 @@
 # Rollback
 `/ledger rollback`  
 Alias: `rb`  
-Permission: `ledger.commands.rollback`
+Permission: `ledger:command/rollback` or permission level 3
 
 ---
 

--- a/docs/commands/root.md
+++ b/docs/commands/root.md
@@ -1,7 +1,7 @@
 # Root
 `/ledger`  
 Alias: `lg`  
-Permission: `ledger.commands.root`
+Permission: `ledger:command/root` or permission level 3
 
 ---
 

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -1,7 +1,7 @@
 # Search
 `/ledger search`  
 Alias: `s`  
-Permission: `ledger.commands.search`
+Permission: `ledger:command/search` or permission level 3
 
 ---
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -1,7 +1,7 @@
 # Status
 `/ledger status`  
 Alias: None  
-Permission: `ledger.commands.status`
+Permission: `ledger:command/status` or permission level 3
 
 ---
 

--- a/docs/commands/teleport.md
+++ b/docs/commands/teleport.md
@@ -1,7 +1,7 @@
 # Teleport
 `/ledger tp`  
 Alias: None  
-Permission: `ledger.commands.tp`
+Permission: `ledger:command/tp` or permission level 3
 
 ---
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -4,11 +4,22 @@ Ledger supports numerous custom packets for interacting with supported client mo
 
 ## Versions
 
+All packets are correct for Ledger Networking v3, which is included in Ledger 1.3.0 and later.
+
 The information on this page is applicable for Ledger Networking version 3, which is the version in Ledger versions `1.3.0` and later
+
+## Permissions
+
+The `ledger:networking` permission is required to interact with Ledger over the networking API. There is no fallback to a permission level: you **must** explicitly give players this permission to be able to use Ledger's functionality over the networking API.
+
+Each packet also requires the permissions that the corresponding command does, but note that this does have fallback to permission level.
+
+### Permissions prior to version 1.3.24
+
+Permission codes were changed in version 1.3.24 to enable support for the Fabric Permissions API v1. In older versions, the `ledger.networking` permission from lucko's [Fabric Permissions API](https://github.com/lucko/fabric-permissions-api) was required in addition to the corresponding packet type permissions, with no fallback to permission level provided for this permission.
 
 ## Packet Types
 
-The server will not respond to packets unless the player has the correct permissions, which is `ledger.networking` and the relevant command permission
 
 #### Notation
 Types shown here are the Java variable types. They have the equivalent value (if applicable) in Kotlin when used in Ledger's internal code
@@ -62,7 +73,7 @@ Mod NBT should contain the following:
 
 - Mod ID (`modid`) [`String`] : Mod identifier of the mod
 
-- Protocol version (`protocol_version`) [`int`] : Ledger protocol version
+- Protocol version (`protocol_version`) [`int`] : Ledger protocol version (currently 3)
 
 ### Purge Packet
 

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,15 +1,13 @@
 [versions]
-minecraft = "26.2-rc-2"
+minecraft = "26.2"
 fabric-loader = "0.19.3"
 
-fabric-api = "0.152.1+26.2"
+fabric-api = "0.158.0+26.2"
 
 # Kotlin
 kotlin = "2.3.10"
 # Also modrinth version in gradle.properties
 fabric-kotlin = "1.13.9+kotlin.2.3.10"
-
-fabric-permissions = "0.7.0"
 translations = "3.1.0+26.2"
 
 exposed = "1.0.0-rc-2"
@@ -26,7 +24,6 @@ fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric-l
 fabric-api = { module = "net.fabricmc.fabric-api:fabric-api", version.ref = "fabric-api" }
 fabric-kotlin = { module = "net.fabricmc:fabric-language-kotlin", version.ref = "fabric-kotlin" }
 
-fabric-permissions = { module = "me.lucko:fabric-permissions-api", version.ref = "fabric-permissions" }
 translations = { module = "xyz.nucleoid:server-translations-api", version.ref = "translations" }
 
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/CommandConsts.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/CommandConsts.kt
@@ -1,6 +1,3 @@
 package com.github.quiltservertools.ledger.commands
 
-object CommandConsts {
-    const val PARAMS = "params"
-    const val PERMISSION_LEVEL = 3
-}
+const val PARAMS = "params"

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/LedgerCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/LedgerCommand.kt
@@ -11,20 +11,21 @@ import com.github.quiltservertools.ledger.commands.subcommands.RollbackCommand
 import com.github.quiltservertools.ledger.commands.subcommands.SearchCommand
 import com.github.quiltservertools.ledger.commands.subcommands.StatusCommand
 import com.github.quiltservertools.ledger.commands.subcommands.TeleportCommand
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.BrigadierUtils
 import com.github.quiltservertools.ledger.utility.Dispatcher
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.commands.Commands.literal
 
 fun registerCommands(dispatcher: Dispatcher) {
     val rootNode =
-        literal("ledger").requires(Permissions.require("ledger.commands.root", CommandConsts.PERMISSION_LEVEL))
+        literal("ledger")
+            .requires(Permissions.has(Permissions.ROOT))
             .build()
 
     dispatcher.root.addChild(rootNode)
     dispatcher.root.addChild(
         literal("lg")
-            .requires(Permissions.require("ledger.commands.root", CommandConsts.PERMISSION_LEVEL)).redirect(rootNode)
+            .requires(Permissions.has(Permissions.ROOT)).redirect(rootNode)
             .build(),
     )
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/arguments/SearchParamArgument.kt
@@ -155,9 +155,9 @@ object SearchParamArgument {
                             builder.sourceNames!!.add(nonPlayer)
                         }
                     } else {
-                        val profile = source.server.services().nameToIdCache?.get(sourceInput.property)
+                        val profile = source.server.services().nameToIdCache.get(sourceInput.property)
                         // If the player doesn't exist use a random UUID to make the query not match
-                        val id = profile?.orElse(null)?.id ?: UUID.randomUUID()
+                        val id = profile.orElse(null)?.id ?: UUID.randomUUID()
 
                         if (id != null) {
                             val playerIdEntry = Negatable(id, sourceInput.allowed)

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/InspectCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/InspectCommand.kt
@@ -1,14 +1,13 @@
 package com.github.quiltservertools.ledger.commands.subcommands
 
 import com.github.quiltservertools.ledger.commands.BuildableCommand
-import com.github.quiltservertools.ledger.commands.CommandConsts
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.Context
 import com.github.quiltservertools.ledger.utility.LiteralNode
 import com.github.quiltservertools.ledger.utility.inspectBlock
 import com.github.quiltservertools.ledger.utility.inspectOff
 import com.github.quiltservertools.ledger.utility.inspectOn
 import com.github.quiltservertools.ledger.utility.isInspecting
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.commands.Commands.argument
 import net.minecraft.commands.Commands.literal
 import net.minecraft.commands.arguments.coordinates.BlockPosArgument
@@ -16,7 +15,7 @@ import net.minecraft.core.BlockPos
 
 object InspectCommand : BuildableCommand {
     override fun build(): LiteralNode = literal("inspect")
-        .requires(Permissions.require("ledger.commands.inspect", CommandConsts.PERMISSION_LEVEL))
+        .requires(Permissions.has(Permissions.INSPECT))
         .executes { toggleInspect(it) }
         .then(
             literal("on")

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PageCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PageCommand.kt
@@ -37,8 +37,8 @@ object PageCommand : BuildableCommand {
                     source,
                     results,
                     Component.translatable(
-                        "text.ledger.header.search"
-                    ).setStyle(TextColorPallet.primary)
+                        "text.ledger.header.search",
+                    ).setStyle(TextColorPallet.primary),
                 )
             }
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PlayerCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PlayerCommand.kt
@@ -2,12 +2,11 @@ package com.github.quiltservertools.ledger.commands.subcommands
 
 import com.github.quiltservertools.ledger.Ledger
 import com.github.quiltservertools.ledger.commands.BuildableCommand
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.database.DatabaseManager
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.LiteralNode
 import com.github.quiltservertools.ledger.utility.MessageUtils
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.commands.CommandSourceStack
 import net.minecraft.commands.Commands.argument
 import net.minecraft.commands.Commands.literal
@@ -17,7 +16,7 @@ import net.minecraft.server.players.NameAndId
 object PlayerCommand : BuildableCommand {
     override fun build(): LiteralNode {
         return literal("player")
-            .requires(Permissions.require("ledger.commands.player", CommandConsts.PERMISSION_LEVEL))
+            .requires(Permissions.has(Permissions.PLAYER))
             .then(
                 argument("player", GameProfileArgument.gameProfile())
                     .executes {

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PreviewCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PreviewCommand.kt
@@ -4,28 +4,28 @@ import com.github.quiltservertools.ledger.Ledger
 import com.github.quiltservertools.ledger.actionutils.ActionSearchParams
 import com.github.quiltservertools.ledger.actionutils.Preview
 import com.github.quiltservertools.ledger.commands.BuildableCommand
-import com.github.quiltservertools.ledger.commands.CommandConsts
+import com.github.quiltservertools.ledger.commands.PARAMS
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.Context
 import com.github.quiltservertools.ledger.utility.LiteralNode
 import com.github.quiltservertools.ledger.utility.MessageUtils
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.commands.Commands
 import net.minecraft.network.chat.Component
 
 object PreviewCommand : BuildableCommand {
     override fun build(): LiteralNode = Commands.literal("preview")
-        .requires(Permissions.require("ledger.commands.preview", CommandConsts.PERMISSION_LEVEL))
+        .requires(Permissions.has(Permissions.PREVIEW))
         .then(
             Commands.literal("rollback")
                 .then(
-                    SearchParamArgument.argument(CommandConsts.PARAMS)
+                    SearchParamArgument.argument(PARAMS)
                         .executes {
                             preview(
                                 it,
-                                SearchParamArgument.get(it, CommandConsts.PARAMS),
+                                SearchParamArgument.get(it, PARAMS),
                                 Preview.Type.ROLLBACK,
                             )
                         },
@@ -34,11 +34,11 @@ object PreviewCommand : BuildableCommand {
         .then(
             Commands.literal("restore")
                 .then(
-                    SearchParamArgument.argument(CommandConsts.PARAMS)
+                    SearchParamArgument.argument(PARAMS)
                         .executes {
                             preview(
                                 it,
-                                SearchParamArgument.get(it, CommandConsts.PARAMS),
+                                SearchParamArgument.get(it, PARAMS),
                                 Preview.Type.RESTORE,
                             )
                         },

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PurgeCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/PurgeCommand.kt
@@ -3,25 +3,23 @@ package com.github.quiltservertools.ledger.commands.subcommands
 import com.github.quiltservertools.ledger.Ledger
 import com.github.quiltservertools.ledger.actionutils.ActionSearchParams
 import com.github.quiltservertools.ledger.commands.BuildableCommand
-import com.github.quiltservertools.ledger.commands.CommandConsts
+import com.github.quiltservertools.ledger.commands.PARAMS
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
-import com.github.quiltservertools.ledger.config.SearchSpec
-import com.github.quiltservertools.ledger.config.config
 import com.github.quiltservertools.ledger.database.DatabaseManager
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.Context
 import com.github.quiltservertools.ledger.utility.LiteralNode
 import com.github.quiltservertools.ledger.utility.TextColorPallet
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.commands.Commands.literal
 import net.minecraft.network.chat.Component
 
 object PurgeCommand : BuildableCommand {
     override fun build(): LiteralNode = literal("purge")
-        .requires(Permissions.require("ledger.commands.purge", config[SearchSpec.purgePermissionLevel]))
+        .requires(Permissions.has(Permissions.PURGE))
         .then(
-            SearchParamArgument.argument(CommandConsts.PARAMS).executes {
-                runPurge(it, SearchParamArgument.get(it, CommandConsts.PARAMS))
+            SearchParamArgument.argument(PARAMS).executes {
+                runPurge(it, SearchParamArgument.get(it, PARAMS))
             },
         )
         .build()

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RestoreCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RestoreCommand.kt
@@ -3,9 +3,9 @@ package com.github.quiltservertools.ledger.commands.subcommands
 import com.github.quiltservertools.ledger.Ledger
 import com.github.quiltservertools.ledger.actionutils.ActionSearchParams
 import com.github.quiltservertools.ledger.commands.BuildableCommand
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.Context
 import com.github.quiltservertools.ledger.utility.LiteralNode
 import com.github.quiltservertools.ledger.utility.MessageUtils
@@ -13,13 +13,12 @@ import com.github.quiltservertools.ledger.utility.TextColorPallet
 import com.github.quiltservertools.ledger.utility.launchMain
 import com.github.quiltservertools.ledger.utility.literal
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.commands.Commands
 import net.minecraft.network.chat.Component
 
 object RestoreCommand : BuildableCommand {
     override fun build(): LiteralNode = Commands.literal("restore")
-        .requires(Permissions.require("ledger.commands.rollback", CommandConsts.PERMISSION_LEVEL))
+        .requires(Permissions.has(Permissions.RESTORE))
         .then(
             SearchParamArgument.argument("params")
                 .executes { restore(it, SearchParamArgument.get(it, "params")) },

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RollbackCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/RollbackCommand.kt
@@ -3,9 +3,9 @@ package com.github.quiltservertools.ledger.commands.subcommands
 import com.github.quiltservertools.ledger.Ledger
 import com.github.quiltservertools.ledger.actionutils.ActionSearchParams
 import com.github.quiltservertools.ledger.commands.BuildableCommand
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.Context
 import com.github.quiltservertools.ledger.utility.LiteralNode
 import com.github.quiltservertools.ledger.utility.MessageUtils
@@ -13,13 +13,12 @@ import com.github.quiltservertools.ledger.utility.TextColorPallet
 import com.github.quiltservertools.ledger.utility.launchMain
 import com.github.quiltservertools.ledger.utility.literal
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.commands.Commands
 import net.minecraft.network.chat.Component
 
 object RollbackCommand : BuildableCommand {
     override fun build(): LiteralNode = Commands.literal("rollback")
-        .requires(Permissions.require("ledger.commands.rollback", CommandConsts.PERMISSION_LEVEL))
+        .requires(Permissions.has(Permissions.ROLLBACK))
         .then(
             SearchParamArgument.argument("params")
                 .executes { rollback(it, SearchParamArgument.get(it, "params")) },

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/SearchCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/SearchCommand.kt
@@ -3,21 +3,20 @@ package com.github.quiltservertools.ledger.commands.subcommands
 import com.github.quiltservertools.ledger.Ledger
 import com.github.quiltservertools.ledger.actionutils.ActionSearchParams
 import com.github.quiltservertools.ledger.commands.BuildableCommand
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.Context
 import com.github.quiltservertools.ledger.utility.LiteralNode
 import com.github.quiltservertools.ledger.utility.MessageUtils
 import com.github.quiltservertools.ledger.utility.TextColorPallet
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.commands.Commands.literal
 import net.minecraft.network.chat.Component
 
 object SearchCommand : BuildableCommand {
     override fun build(): LiteralNode = literal("search")
-        .requires(Permissions.require("ledger.commands.search", CommandConsts.PERMISSION_LEVEL))
+        .requires(Permissions.has(Permissions.SEARCH))
         .then(
             SearchParamArgument.argument("params")
                 .executes { search(it, SearchParamArgument.get(it, "params")) },

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/StatusCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/StatusCommand.kt
@@ -2,16 +2,15 @@ package com.github.quiltservertools.ledger.commands.subcommands
 
 import com.github.quiltservertools.ledger.Ledger
 import com.github.quiltservertools.ledger.commands.BuildableCommand
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.database.ActionQueueService
 import com.github.quiltservertools.ledger.database.DatabaseManager
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.Context
 import com.github.quiltservertools.ledger.utility.LiteralNode
 import com.github.quiltservertools.ledger.utility.TextColorPallet
 import com.github.quiltservertools.ledger.utility.literal
 import com.github.quiltservertools.ledger.utility.translate
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.fabricmc.loader.api.FabricLoader
 import net.fabricmc.loader.api.SemanticVersion
 import net.minecraft.commands.Commands
@@ -21,7 +20,7 @@ import java.net.URI
 
 object StatusCommand : BuildableCommand {
     override fun build(): LiteralNode = Commands.literal("status")
-        .requires(Permissions.require("ledger.commands.status", CommandConsts.PERMISSION_LEVEL))
+        .requires(Permissions.has(Permissions.STATUS))
         .executes { status(it) }
         .build()
 

--- a/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/TeleportCommand.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/commands/subcommands/TeleportCommand.kt
@@ -1,10 +1,9 @@
 package com.github.quiltservertools.ledger.commands.subcommands
 
 import com.github.quiltservertools.ledger.commands.BuildableCommand
-import com.github.quiltservertools.ledger.commands.CommandConsts
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.Context
 import com.github.quiltservertools.ledger.utility.LiteralNode
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.minecraft.commands.Commands
 import net.minecraft.commands.arguments.DimensionArgument
 import net.minecraft.commands.arguments.coordinates.Coordinates
@@ -16,7 +15,7 @@ import net.minecraft.server.level.ServerPlayer
 object TeleportCommand : BuildableCommand {
     private const val BLOCK_CENTER_OFFSET = 0.5
     override fun build(): LiteralNode = Commands.literal("tp")
-        .requires(Permissions.require("ledger.commands.tp", CommandConsts.PERMISSION_LEVEL))
+        .requires(Permissions.has(Permissions.TP))
         .then(
             Commands.argument("world", DimensionArgument.dimension())
                 .then(
@@ -42,7 +41,7 @@ object TeleportCommand : BuildableCommand {
     }
 
     fun teleport(player: ServerPlayer, world: ServerLevel, pos: BlockPos) {
-        if (!Permissions.check(player, "ledger.commands.tp", CommandConsts.PERMISSION_LEVEL)) return
+        if (!Permissions.check(player, Permissions.TP)) return
 
         val x = pos.x.toDouble() + BLOCK_CENTER_OFFSET
         val z = pos.z.toDouble() + BLOCK_CENTER_OFFSET

--- a/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/HandshakeC2SPacket.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/HandshakeC2SPacket.kt
@@ -1,15 +1,14 @@
 package com.github.quiltservertools.ledger.network.packet.receiver
 
 import com.github.quiltservertools.ledger.Ledger
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.logInfo
 import com.github.quiltservertools.ledger.network.Networking
 import com.github.quiltservertools.ledger.network.Networking.enableNetworking
 import com.github.quiltservertools.ledger.network.packet.LedgerPacketTypes
 import com.github.quiltservertools.ledger.network.packet.handshake.HandshakeContent
 import com.github.quiltservertools.ledger.network.packet.handshake.ModInfo
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.registry.ActionRegistry
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
 import net.fabricmc.loader.api.FabricLoader
 import net.minecraft.nbt.CompoundTag
@@ -31,7 +30,7 @@ data class HandshakeC2SPacket(val nbt: CompoundTag?) : CustomPacketPayload {
 
         override fun receive(payload: HandshakeC2SPacket, context: ServerPlayNetworking.Context) {
             val player = context.player()
-            if (!Permissions.check(player, "ledger.networking", CommandConsts.PERMISSION_LEVEL)) return
+            if (!Permissions.check(player, Permissions.NETWORKING)) return
             // This should be sent by the client whenever a player joins with a client mod
             // We do some validation on the packet to make sure it's complete and intact
             val info = readInfo(payload.nbt)

--- a/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/InspectC2SPacket.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/InspectC2SPacket.kt
@@ -1,16 +1,15 @@
 package com.github.quiltservertools.ledger.network.packet.receiver
 
 import com.github.quiltservertools.ledger.Ledger
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.database.DatabaseManager
 import com.github.quiltservertools.ledger.network.packet.LedgerPacketTypes
 import com.github.quiltservertools.ledger.network.packet.action.ActionS2CPacket
 import com.github.quiltservertools.ledger.network.packet.response.ResponseCodes
 import com.github.quiltservertools.ledger.network.packet.response.ResponseContent
 import com.github.quiltservertools.ledger.network.packet.response.ResponseS2CPacket
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.getInspectResults
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
 import net.minecraft.core.BlockPos
 import net.minecraft.network.FriendlyByteBuf
@@ -30,8 +29,8 @@ data class InspectC2SPacket(val pos: BlockPos, val pages: Int) : CustomPacketPay
         override fun receive(payload: InspectC2SPacket, context: ServerPlayNetworking.Context) {
             val player = context.player()
             val sender = context.responseSender()
-            if (!Permissions.check(player, "ledger.networking", CommandConsts.PERMISSION_LEVEL) ||
-                !Permissions.check(player, "ledger.commands.inspect", CommandConsts.PERMISSION_LEVEL)
+            if (!Permissions.check(player, Permissions.NETWORKING) ||
+                !Permissions.check(player, Permissions.INSPECT)
             ) {
                 ResponseS2CPacket.sendResponse(
                     ResponseContent(

--- a/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/PurgeC2SPacket.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/PurgeC2SPacket.kt
@@ -1,16 +1,15 @@
 package com.github.quiltservertools.ledger.network.packet.receiver
 
 import com.github.quiltservertools.ledger.Ledger
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.database.DatabaseManager
 import com.github.quiltservertools.ledger.network.packet.LedgerPacketTypes
 import com.github.quiltservertools.ledger.network.packet.action.ActionS2CPacket
 import com.github.quiltservertools.ledger.network.packet.response.ResponseCodes
 import com.github.quiltservertools.ledger.network.packet.response.ResponseContent
 import com.github.quiltservertools.ledger.network.packet.response.ResponseS2CPacket
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.getInspectResults
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
 import net.minecraft.core.BlockPos
 import net.minecraft.network.FriendlyByteBuf
@@ -30,8 +29,8 @@ data class PurgeC2SPacket(val pos: BlockPos, val pages: Int) : CustomPacketPaylo
         override fun receive(payload: PurgeC2SPacket, context: ServerPlayNetworking.Context) {
             val player = context.player()
             val sender = context.responseSender()
-            if (!Permissions.check(player, "ledger.networking", CommandConsts.PERMISSION_LEVEL) ||
-                !Permissions.check(player, "ledger.commands.inspect", CommandConsts.PERMISSION_LEVEL)
+            if (!Permissions.check(player, Permissions.NETWORKING) ||
+                !Permissions.check(player, Permissions.PURGE)
             ) {
                 ResponseS2CPacket.sendResponse(
                     ResponseContent(

--- a/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/RollbackC2SPacket.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/RollbackC2SPacket.kt
@@ -1,15 +1,14 @@
 package com.github.quiltservertools.ledger.network.packet.receiver
 
 import com.github.quiltservertools.ledger.Ledger
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
 import com.github.quiltservertools.ledger.network.packet.LedgerPacketTypes
 import com.github.quiltservertools.ledger.network.packet.response.ResponseCodes
 import com.github.quiltservertools.ledger.network.packet.response.ResponseContent
 import com.github.quiltservertools.ledger.network.packet.response.ResponseS2CPacket
+import com.github.quiltservertools.ledger.permissions.Permissions
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
 import net.minecraft.network.FriendlyByteBuf
 import net.minecraft.network.codec.StreamCodec
@@ -28,8 +27,8 @@ data class RollbackC2SPacket(val input: String) : CustomPacketPayload {
         override fun receive(payload: RollbackC2SPacket, context: ServerPlayNetworking.Context) {
             val player = context.player()
             val sender = context.responseSender()
-            if (!Permissions.check(player, "ledger.networking", CommandConsts.PERMISSION_LEVEL) ||
-                !Permissions.check(player, "ledger.commands.purge", CommandConsts.PERMISSION_LEVEL)
+            if (!Permissions.check(player, Permissions.NETWORKING) ||
+                !Permissions.check(player, Permissions.ROLLBACK)
             ) {
                 ResponseS2CPacket.sendResponse(
                     ResponseContent(LedgerPacketTypes.PURGE.id, ResponseCodes.NO_PERMISSION.code),

--- a/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/SearchC2SPacket.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/network/packet/receiver/SearchC2SPacket.kt
@@ -1,17 +1,16 @@
 package com.github.quiltservertools.ledger.network.packet.receiver
 
 import com.github.quiltservertools.ledger.Ledger
-import com.github.quiltservertools.ledger.commands.CommandConsts
 import com.github.quiltservertools.ledger.commands.arguments.SearchParamArgument
 import com.github.quiltservertools.ledger.database.DatabaseManager
 import com.github.quiltservertools.ledger.network.packet.LedgerPacketTypes
 import com.github.quiltservertools.ledger.network.packet.response.ResponseCodes
 import com.github.quiltservertools.ledger.network.packet.response.ResponseContent
 import com.github.quiltservertools.ledger.network.packet.response.ResponseS2CPacket
+import com.github.quiltservertools.ledger.permissions.Permissions
 import com.github.quiltservertools.ledger.utility.MessageUtils
 import com.github.quiltservertools.ledger.utility.TextColorPallet
 import kotlinx.coroutines.launch
-import me.lucko.fabric.api.permissions.v0.Permissions
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
 import net.minecraft.network.FriendlyByteBuf
 import net.minecraft.network.chat.Component
@@ -31,8 +30,8 @@ data class SearchC2SPacket(val args: String, val pages: Int) : CustomPacketPaylo
         override fun receive(payload: SearchC2SPacket, context: ServerPlayNetworking.Context) {
             val player = context.player()
             val sender = context.responseSender()
-            if (!Permissions.check(player, "ledger.networking", CommandConsts.PERMISSION_LEVEL) ||
-                !Permissions.check(player, "ledger.commands.search", CommandConsts.PERMISSION_LEVEL)
+            if (!Permissions.check(player, Permissions.NETWORKING) ||
+                !Permissions.check(player, Permissions.SEARCH)
             ) {
                 ResponseS2CPacket.sendResponse(
                     ResponseContent(

--- a/src/main/kotlin/com/github/quiltservertools/ledger/permissions/Permissions.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/permissions/Permissions.kt
@@ -1,0 +1,41 @@
+package com.github.quiltservertools.ledger.permissions
+
+import com.github.quiltservertools.ledger.config.SearchSpec
+import com.github.quiltservertools.ledger.config.config
+import net.fabricmc.fabric.api.permission.v1.PermissionPredicates
+import net.minecraft.commands.CommandSourceStack
+import net.minecraft.resources.Identifier
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.server.permissions.PermissionLevel
+import java.util.function.Predicate
+
+private const val NAMESPACE = "ledger"
+val DEFAULT_PERMISSION_LEVEL = PermissionLevel.ADMINS
+
+enum class Permissions(
+    private val identifier: Identifier,
+    private val fallback: PermissionLevel = DEFAULT_PERMISSION_LEVEL,
+) {
+    ROOT(commandIdentifier("root")),
+    INSPECT(commandIdentifier("inspect")),
+    NETWORKING(Identifier.fromNamespaceAndPath(NAMESPACE, "networking")),
+    PLAYER(commandIdentifier("player")),
+    PREVIEW(commandIdentifier("preview")),
+    PURGE(commandIdentifier("purge"), PermissionLevel.byId(config[SearchSpec.purgePermissionLevel])),
+    ROLLBACK(commandIdentifier("rollback")),
+    RESTORE(commandIdentifier("restore")),
+    SEARCH(commandIdentifier("search")),
+    STATUS(commandIdentifier("status")),
+    TP(commandIdentifier("tp")),
+    ;
+
+    companion object {
+        fun has(perm: Permissions): Predicate<CommandSourceStack> =
+            PermissionPredicates.require(perm.identifier, perm.fallback)
+
+        fun check(player: ServerPlayer, perm: Permissions): Boolean =
+            player.permissionContext.checkPermission(perm.identifier).get()
+    }
+}
+
+private fun commandIdentifier(name: String) = Identifier.fromNamespaceAndPath(NAMESPACE, "command/$name")

--- a/src/main/kotlin/com/github/quiltservertools/ledger/utility/MessageUtils.kt
+++ b/src/main/kotlin/com/github/quiltservertools/ledger/utility/MessageUtils.kt
@@ -26,7 +26,7 @@ import kotlin.time.toKotlinDuration
 object MessageUtils {
     val pageChangeAction: Identifier = Ledger.identifier("page-change")
     val teleportAction: Identifier = Ledger.identifier("teleport")
-    
+
     @OptIn(ExperimentalTime::class)
     suspend fun sendSearchResults(source: CommandSourceStack, results: SearchResults, header: Component) {
         // If the player has a Ledger compatible client, we send results as action packets rather than as chat messages
@@ -50,17 +50,17 @@ object MessageUtils {
             Component.translatable(
                 "text.ledger.footer.search",
                 Component.translatable(
-                    "text.ledger.footer.page_backward"
+                    "text.ledger.footer.page_backward",
                 ).setStyle(TextColorPallet.primaryVariant).withStyle {
-                    val tag: CompoundTag = CompoundTag().apply { this.putInt("page", results.page-1) }
-                    
+                    val tag: CompoundTag = CompoundTag().apply { this.putInt("page", results.page - 1) }
+
                     if (results.page > 1) {
                         it.withHoverEvent(
                             HoverEvent.ShowText(
-                                Component.translatable("text.ledger.footer.page_backward.hover")
-                            )
+                                Component.translatable("text.ledger.footer.page_backward.hover"),
+                            ),
                         ).withClickEvent(
-                            ClickEvent.Custom(pageChangeAction, Optional.of(tag))
+                            ClickEvent.Custom(pageChangeAction, Optional.of(tag)),
                         )
                     } else {
                         Style.EMPTY
@@ -69,23 +69,23 @@ object MessageUtils {
                 results.page.toString().literal().setStyle(TextColorPallet.primaryVariant),
                 results.pages.toString().literal().setStyle(TextColorPallet.primaryVariant),
                 Component.translatable(
-                    "text.ledger.footer.page_forward"
+                    "text.ledger.footer.page_forward",
                 ).setStyle(TextColorPallet.primaryVariant).withStyle {
-                    val tag: CompoundTag = CompoundTag().apply { this.putInt("page", results.page+1) }
+                    val tag: CompoundTag = CompoundTag().apply { this.putInt("page", results.page + 1) }
 
                     if (results.page < results.pages) {
                         it.withHoverEvent(
                             HoverEvent.ShowText(
-                                Component.translatable("text.ledger.footer.page_forward.hover")
-                            )
+                                Component.translatable("text.ledger.footer.page_forward.hover"),
+                            ),
                         ).withClickEvent(
-                            ClickEvent.Custom(pageChangeAction, Optional.of(tag))
+                            ClickEvent.Custom(pageChangeAction, Optional.of(tag)),
                         )
                     } else {
                         Style.EMPTY
                     }
-                }
-            ).setStyle(TextColorPallet.primary)
+                },
+            ).setStyle(TextColorPallet.primary),
         )
     }
 
@@ -135,8 +135,8 @@ object MessageUtils {
         message.withStyle {
             it.withHoverEvent(
                 HoverEvent.ShowText(
-                    timeMessage
-                )
+                    timeMessage,
+                ),
             )
         }
         return message


### PR DESCRIPTION
Implements the Fabric Permissions API v1.

New permissions for commands: `ledger:command/<command_full_name>`

- Changes commands to use Fabric Permissions API v1
- Commands fall back to permission level 3 except for purge which still relies on the config
- Changed networking base permission to `ledger:networking`, there remains no fallback (this must be explicitly given instead of via permission level)
- Updated docs to reflect above
- Bumped MC version to 26.2 and FAPI to 0.158.0

Closes #377